### PR TITLE
avoid printing custom errors

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	// collector does not have permission for.
 	// See https://github.com/open-telemetry/opentelemetry-collector/issues/3004 for more information.
 	MuteProcessNameError bool `mapstructure:"mute_process_name_error,omitempty"`
+	AvoidSelectedErrors  bool `mapstructure:"avoid_selected_errors,omitempty"`
 
 	// ScrapeProcessDelay is used to indicate the minimum amount of time a process must be running
 	// before metrics are scraped for it.  The default value is 0 seconds (0s)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -180,7 +180,7 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 		}
 
 		username, err := handle.Username()
-		if err != nil {
+		if err != nil && !s.config.AvoidSelectedErrors {
 			errs.AddPartial(0, fmt.Errorf("error reading username for process %q (pid %v): %w", executable.name, pid, err))
 		}
 
@@ -195,7 +195,7 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 		}
 
 		parentPid, err := parentPid(handle, pid)
-		if err != nil {
+		if err != nil && !s.config.AvoidSelectedErrors {{
 			errs.AddPartial(0, fmt.Errorf("error reading parent pid for process %q (pid %v): %w", executable.name, pid, err))
 		}
 


### PR DESCRIPTION
Avoid printing username and parentid errors for hostmetricsreceiver