### PR TITLE
ENG-461 Linux-specific methods have been added to avoid macOS compilation errors.

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_darwin.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_darwin.go
@@ -16,6 +16,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal"
 )
 
+func (s *scraper) recordCPUPercentMetric(now pcommon.Timestamp, cpuPercent float64) {
+	s.mb.RecordProcessCPUPercentDataPoint(now, cpuPercent)
+}
+
+func (s *scraper) recordMemoryPercentMetric(now pcommon.Timestamp, memoryPercent float32) {
+	s.mb.RecordProcessMemoryPercentDataPoint(now, float64(memoryPercent))
+}
+
 func (s *scraper) recordCPUTimeMetric(now pcommon.Timestamp, cpuTime *cpu.TimesStat) {
 	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.User, metadata.AttributeStateUser)
 	s.mb.RecordProcessCPUTimeDataPoint(now, cpuTime.System, metadata.AttributeStateSystem)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -435,11 +435,6 @@ func (p *processHandleMock) MemoryInfo() (*process.MemoryInfoStat, error) {
 	return args.Get(0).(*process.MemoryInfoStat), args.Error(1)
 }
 
-func (p *processHandleMock) MemoryPercent() (float32, error) {
-	args := p.MethodCalled("MemoryPercent")
-	return args.Get(0).(float32), args.Error(1)
-}
-
 func (p *processHandleMock) IOCounters() (*process.IOCountersStat, error) {
 	args := p.MethodCalled("IOCounters")
 	return args.Get(0).(*process.IOCountersStat), args.Error(1)


### PR DESCRIPTION
Description:
Linux-specific methods have been added to avoid macOS compilation errors. This is a blocking PR for completing [ENG-460](https://linear.app/middleware/issue/ENG-460/support-for-macos-agent-dev-environment). Once the changes are merged and released, I will raise the PR for ENG-460.

Link to tracking Issue: N/A

Testing: Manual testing done. 

Documentation: N/A