### PR TITLE
ENG-947 & ENG-1241: Removed Persistent-Volume from transformObject flow

### DIFF
--- a/receiver/k8sclusterreceiver/informer_transform.go
+++ b/receiver/k8sclusterreceiver/informer_transform.go
@@ -12,7 +12,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/deployment"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/jobs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/node"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/persistentvolume"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/pod"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/replicaset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/service"
@@ -27,8 +26,6 @@ func transformObject(object interface{}) (interface{}, error) {
 		return pod.Transform(o), nil
 	case *corev1.Node:
 		return node.Transform(o), nil
-	case *corev1.PersistentVolume:
-		return persistentvolume.Transform(o), nil
 	case *appsv1.ReplicaSet:
 		return replicaset.Transform(o), nil
 	case *batchv1.Job:


### PR DESCRIPTION
**Description:** 
ENG-947 & ENG-1241: Removed Persistent-Volume from transformObject flow

**Link to tracking Issue:** 
https://linear.app/middleware/issue/ENG-947/need-to-add-persistent-volume-claims-data-in-k8s
https://linear.app/middleware/issue/ENG-1241/add-volume-data-in-k8s-screen-in-ui