### PR TITLE
Mysql metrics/query perf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver v0.84.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver v0.84.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver v0.84.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadoglogreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.84.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.84.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.84.0

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver v0.84.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver v0.84.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver v0.84.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadoglogreceiver v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadoglogreceiver v0.84.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.84.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.84.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.84.0

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -304,7 +304,6 @@ func (c *mySQLClient) getStatementEventsStats() ([]StatementEventStats, error) {
 		}
 		stats = append(stats, s)
 	}
-	fmt.Println(stats)
 	return stats, nil
 }
 

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -285,11 +285,7 @@ func (c *mySQLClient) getStatementEventsStats() ([]StatementEventStats, error) {
 		int64(c.statementEventsTimeLimit.Seconds()),
 		c.statementEventsLimit)
 
-	fmt.Println(c.statementEventsDigestTextLimit)
-	fmt.Println(int64(c.statementEventsTimeLimit.Seconds()))
-	fmt.Println(c.statementEventsLimit)
 	rows, err := c.client.Query(query)
-	fmt.Println(rows)
 	if err != nil {
 		fmt.Println(err.Error())
 		return nil, err

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -71,6 +71,7 @@ type StatementEventStats struct {
 	countSortMergePasses      int64
 	countSortRows             int64
 	countNoIndexUsed          int64
+	countStar                 int64
 }
 
 type tableLockWaitEventStats struct {
@@ -275,7 +276,7 @@ func (c *mySQLClient) getStatementEventsStats() ([]StatementEventStats, error) {
 		"LEFT(DIGEST_TEXT, %d) as DIGEST_TEXT, SUM_TIMER_WAIT, SUM_ERRORS,"+
 		"SUM_WARNINGS, SUM_ROWS_AFFECTED, SUM_ROWS_SENT, SUM_ROWS_EXAMINED,"+
 		"SUM_CREATED_TMP_DISK_TABLES, SUM_CREATED_TMP_TABLES, SUM_SORT_MERGE_PASSES,"+
-		"SUM_SORT_ROWS, SUM_NO_INDEX_USED "+
+		"SUM_SORT_ROWS, SUM_NO_INDEX_USED , COUNT_STAR "+
 		"FROM performance_schema.events_statements_summary_by_digest "+
 		"WHERE SCHEMA_NAME NOT IN ('mysql', 'performance_schema', 'information_schema') "+
 		"AND last_seen > DATE_SUB(NOW(), INTERVAL %d SECOND) "+
@@ -298,7 +299,7 @@ func (c *mySQLClient) getStatementEventsStats() ([]StatementEventStats, error) {
 		err := rows.Scan(&s.schema, &s.digest, &s.digestText,
 			&s.sumTimerWait, &s.countErrors, &s.countWarnings,
 			&s.countRowsAffected, &s.countRowsSent, &s.countRowsExamined, &s.countCreatedTmpDiskTables,
-			&s.countCreatedTmpTables, &s.countSortMergePasses, &s.countSortRows, &s.countNoIndexUsed)
+			&s.countCreatedTmpTables, &s.countSortMergePasses, &s.countSortRows, &s.countNoIndexUsed, &s.countStar)
 		if err != nil {
 			return nil, err
 		}

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -285,8 +285,13 @@ func (c *mySQLClient) getStatementEventsStats() ([]StatementEventStats, error) {
 		int64(c.statementEventsTimeLimit.Seconds()),
 		c.statementEventsLimit)
 
+	fmt.Println(c.statementEventsDigestTextLimit)
+	fmt.Println(int64(c.statementEventsTimeLimit.Seconds()))
+	fmt.Println(c.statementEventsLimit)
 	rows, err := c.client.Query(query)
+	fmt.Println(rows)
 	if err != nil {
+		fmt.Println(err.Error())
 		return nil, err
 	}
 	defer rows.Close()
@@ -303,7 +308,7 @@ func (c *mySQLClient) getStatementEventsStats() ([]StatementEventStats, error) {
 		}
 		stats = append(stats, s)
 	}
-
+	fmt.Println(stats)
 	return stats, nil
 }
 

--- a/receiver/mysqlreceiver/config.go
+++ b/receiver/mysqlreceiver/config.go
@@ -4,6 +4,7 @@
 package mysqlreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver"
 
 import (
+	"math"
 	"time"
 
 	"go.opentelemetry.io/collector/config/confignet"
@@ -16,7 +17,7 @@ import (
 const (
 	defaultStatementEventsDigestTextLimit = 120
 	defaultStatementEventsLimit           = 250
-	defaultStatementEventsTimeLimit       = 24 * time.Hour
+	defaultStatementEventsTimeLimit       = time.Duration(math.MaxInt64)
 )
 
 type Config struct {

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -288,6 +288,23 @@ The number of MySQL sorts.
 | ---- | ----------- | ------ |
 | kind | The sort count type. | Str: ``merge_passes``, ``range``, ``rows``, ``scan`` |
 
+### mysql.statement_event.count
+
+Summary of current and recent statement events.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| 1 | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| schema | The schema of the object. | Any Str |
+| digest | Digest. | Any Str |
+| digest_text | Text before digestion. | Any Str |
+| kind | Possible event states. | Str: ``errors``, ``warnings``, ``rows_affected``, ``rows_sent``, ``rows_examined``, ``created_tmp_disk_tables``, ``created_tmp_tables``, ``sort_merge_passes``, ``sort_rows``, ``no_index_used`` |
+
 ### mysql.table.io.wait.count
 
 The total count of I/O wait events for a table.
@@ -486,30 +503,13 @@ This field is an indication of how “late” the replica is.
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | s | Sum | Int | Cumulative | false |
 
-### mysql.statement_event.count
-
-Summary of current and recent statement events.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | false |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| schema | The schema of the object. | Any Str |
-| digest | Digest. | Any Str |
-| digest_text | Text before digestion. | Any Str |
-| kind | Possible event states. | Str: ``errors``, ``warnings``, ``rows_affected``, ``rows_sent``, ``rows_examined``, ``created_tmp_disk_tables``, ``created_tmp_tables``, ``sort_merge_passes``, ``sort_rows``, ``no_index_used`` |
-
 ### mysql.statement_event.wait.time
 
 The total wait time of the summarized timed events.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| ns | Sum | Int | Cumulative | false |
+| ns | Sum | Int | Cumulative | true |
 
 #### Attributes
 

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -305,6 +305,22 @@ Summary of current and recent statement events.
 | digest_text | Text before digestion. | Any Str |
 | kind | Possible event states. | Str: ``errors``, ``warnings``, ``rows_affected``, ``rows_sent``, ``rows_examined``, ``created_tmp_disk_tables``, ``created_tmp_tables``, ``sort_merge_passes``, ``sort_rows``, ``no_index_used`` |
 
+### mysql.statement_event.wait.time
+
+The total wait time of the summarized timed events.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| ns | Sum | Int | Cumulative | true |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| schema | The schema of the object. | Any Str |
+| digest | Digest. | Any Str |
+| digest_text | Text before digestion. | Any Str |
+
 ### mysql.table.io.wait.count
 
 The total count of I/O wait events for a table.
@@ -502,22 +518,6 @@ This field is an indication of how “late” the replica is.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | s | Sum | Int | Cumulative | false |
-
-### mysql.statement_event.wait.time
-
-The total wait time of the summarized timed events.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ns | Sum | Int | Cumulative | true |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| schema | The schema of the object. | Any Str |
-| digest | Digest. | Any Str |
-| digest_text | Text before digestion. | Any Str |
 
 ### mysql.table.lock_wait.read.count
 

--- a/receiver/mysqlreceiver/go.mod
+++ b/receiver/mysqlreceiver/go.mod
@@ -20,6 +20,11 @@ require (
 )
 
 require (
+	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+)
+
+require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
@@ -36,6 +41,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/knadh/koanf/v2 v2.0.1 // indirect

--- a/receiver/mysqlreceiver/go.sum
+++ b/receiver/mysqlreceiver/go.sum
@@ -187,6 +187,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd9g2S9Z40=
+github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
@@ -209,11 +211,13 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -166,7 +166,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		MysqlStatementEventCount: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		MysqlStatementEventWaitTime: MetricConfig{
 			Enabled: false,

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -169,7 +169,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		MysqlStatementEventWaitTime: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		MysqlTableIoWaitCount: MetricConfig{
 			Enabled: true,

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -2684,7 +2684,7 @@ func (m *metricMysqlStatementEventWaitTime) init() {
 	m.data.SetDescription("The total wait time of the summarized timed events.")
 	m.data.SetUnit("ns")
 	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -167,6 +167,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordMysqlSortsDataPoint(ts, "1", AttributeSortsMergePasses)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlStatementEventCountDataPoint(ts, 1, "schema-val", "digest-val", "digest_text-val", AttributeEventStateErrors)
 
@@ -786,7 +787,7 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
 					assert.Equal(t, "The total wait time of the summarized timed events.", ms.At(i).Description())
 					assert.Equal(t, "ns", ms.At(i).Unit())
-					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
+					assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
 					dp := ms.At(i).Sum().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -171,6 +171,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordMysqlStatementEventCountDataPoint(ts, 1, "schema-val", "digest-val", "digest_text-val", AttributeEventStateErrors)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlStatementEventWaitTimeDataPoint(ts, 1, "schema-val", "digest-val", "digest_text-val")
 

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -514,7 +514,7 @@ metrics:
       aggregation_temporality: cumulative
     attributes: []
   mysql.statement_event.count:
-    enabled: false
+    enabled: true
     description: Summary of current and recent statement events.
     unit: 1
     sum:
@@ -528,7 +528,7 @@ metrics:
     unit: ns
     sum:
       value_type: int
-      monotonic: false
+      monotonic: true
       aggregation_temporality: cumulative
     attributes: [schema, digest, digest_text]
   mysql.mysqlx_worker_threads:

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -523,7 +523,7 @@ metrics:
       aggregation_temporality: cumulative
     attributes: [schema, digest, digest_text, event_state]
   mysql.statement_event.wait.time:
-    enabled: false
+    enabled: true
     description: The total wait time of the summarized timed events.
     unit: ns
     sum:

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -528,7 +528,7 @@ metrics:
     unit: ns
     sum:
       value_type: int
-      monotonic: true
+      monotonic: false
       aggregation_temporality: cumulative
     attributes: [schema, digest, digest_text]
   mysql.mysqlx_worker_threads:

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -6,7 +6,6 @@ package mysqlreceiver // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -481,11 +480,8 @@ func (m *mySQLScraper) scrapeStatementEventsStats(now pcommon.Timestamp, errs *s
 		return
 	}
 
-	// fmt.Println(statementEventsStats)
-
 	for i := 0; i < len(statementEventsStats); i++ {
 		s := statementEventsStats[i]
-		fmt.Println(s)
 		m.mb.RecordMysqlStatementEventCountDataPoint(now, s.countCreatedTmpDiskTables, s.schema, s.digest, s.digestText, metadata.AttributeEventStateCreatedTmpDiskTables)
 		m.mb.RecordMysqlStatementEventCountDataPoint(now, s.countCreatedTmpTables, s.schema, s.digest, s.digestText, metadata.AttributeEventStateCreatedTmpTables)
 		m.mb.RecordMysqlStatementEventCountDataPoint(now, s.countErrors, s.schema, s.digest, s.digestText, metadata.AttributeEventStateErrors)

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -6,6 +6,7 @@ package mysqlreceiver // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -480,8 +481,11 @@ func (m *mySQLScraper) scrapeStatementEventsStats(now pcommon.Timestamp, errs *s
 		return
 	}
 
+	// fmt.Println(statementEventsStats)
+
 	for i := 0; i < len(statementEventsStats); i++ {
 		s := statementEventsStats[i]
+		fmt.Println(s)
 		m.mb.RecordMysqlStatementEventCountDataPoint(now, s.countCreatedTmpDiskTables, s.schema, s.digest, s.digestText, metadata.AttributeEventStateCreatedTmpDiskTables)
 		m.mb.RecordMysqlStatementEventCountDataPoint(now, s.countCreatedTmpTables, s.schema, s.digest, s.digestText, metadata.AttributeEventStateCreatedTmpTables)
 		m.mb.RecordMysqlStatementEventCountDataPoint(now, s.countErrors, s.schema, s.digest, s.digestText, metadata.AttributeEventStateErrors)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Enabled two metrics: 

mysql.statement_event.count:
Number of times a normalized statement is executed. 

mysql.statement_event.wait.time:
Cumulative time for the said normalized statement.

