### PR TITLE
Added dd resource attribute for mysql and psql dd agent metrics

### DIFF
--- a/receiver/datadogmetricreceiver/factory.go
+++ b/receiver/datadogmetricreceiver/factory.go
@@ -28,7 +28,7 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: confighttp.ServerConfig{
-			Endpoint: "localhost:8122",
+			Endpoint: "localhost:8177",
 		},
 		ReadTimeout: 60 * time.Second,
 	}

--- a/receiver/datadogmetricreceiver/factory.go
+++ b/receiver/datadogmetricreceiver/factory.go
@@ -28,7 +28,7 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: confighttp.ServerConfig{
-			Endpoint: "localhost:8177",
+			Endpoint: "localhost:8122",
 		},
 		ReadTimeout: 60 * time.Second,
 	}

--- a/receiver/datadogmetricreceiver/go.mod
+++ b/receiver/datadogmetricreceiver/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.102.2-0.20240606174409-6888f8f7a45f
 	go.opentelemetry.io/collector/config/confighttp v0.102.0
+	go.opentelemetry.io/collector/confmap v0.102.0
 	go.opentelemetry.io/collector/consumer v0.102.0
 	go.opentelemetry.io/collector/pdata v1.10.0
 	go.opentelemetry.io/collector/receiver v0.102.0
@@ -55,7 +56,6 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.102.2-0.20240606174409-6888f8f7a45f // indirect
 	go.opentelemetry.io/collector/config/configtls v0.102.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.102.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.102.0 // indirect
 	go.opentelemetry.io/collector/extension v0.102.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.102.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.9.0 // indirect


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Adding resource attributes for the postgresql and mysql metrics sent by the datadog agent. The resource attributes are `dd.postgresql: Bool(true)` and `dd.mysql: Bool(true)`.
