### PR TITLE
fix: prevent panic when MySQL version lookup fails

### DIFF
--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -125,9 +125,16 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 	version, err := m.sqlclient.getVersion()
 	if err != nil {
 		m.logger.Error("Failed to fetch the version of mysql database", zap.Error(err))
+		// Set a fallback version or skip setting it
+		rb.SetMysqlDbVersion("unknown")
+	} else if version != nil {
+		// Only set the version if it's not nil
+		rb.SetMysqlDbVersion(version.String())
+	} else {
+		// The case where version is nil but no error was returned
+		rb.SetMysqlDbVersion("unknown")
 	}
 
-	rb.SetMysqlDbVersion(version.String())
 	rb.SetMysqlInstanceEndpoint(m.config.Endpoint)
 	m.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fixes a critical bug in the MySQL receiver where the collector would panic when it couldn't connect to a MySQL server. The issue occurred because the code was trying to call String() on a nil version object after failing to get the MySQL version. This fix properly handles the nil version by adding appropriate nil checks and providing fallback values.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue [AGE-193](https://linear.app/middleware/issue/AGE-193/failing-mysql-integration-makes-agent-stuck-in-restart-loop)
