### PR TITLE
ENG-4799 Extended Resource Detection

### DIFF
--- a/internal/metadataproviders/system/metadata.go
+++ b/internal/metadataproviders/system/metadata.go
@@ -76,14 +76,14 @@ type Provider interface {
 }
 
 type InterfaceIP struct {
-    IP            net.IP
-    InterfaceName string
+	IP            net.IP
+	InterfaceName string
 }
 
 // Define a new struct for interface MACs
 type InterfaceMAC struct {
-    MAC           net.HardwareAddr
-    InterfaceName string
+	MAC           net.HardwareAddr
+	InterfaceName string
 }
 
 type systemMetadataProvider struct {
@@ -209,9 +209,9 @@ func (p systemMetadataProvider) HostIPs() (interfaceIPs []InterfaceIP, err error
 			}
 
 			interfaceIPs = append(interfaceIPs, InterfaceIP{
-                IP:            ip,
-                InterfaceName: iface.Name,
-            })
+				IP:            ip,
+				InterfaceName: iface.Name,
+			})
 		}
 	}
 	return interfaceIPs, err
@@ -228,7 +228,6 @@ func (p systemMetadataProvider) HostMACs() (interfaceMACs []InterfaceMAC, err er
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
 			continue
 		}
-	
 		interfaceMACs = append(interfaceMACs, InterfaceMAC{
 			MAC:           iface.HardwareAddr,
 			InterfaceName: iface.Name,

--- a/internal/metadataproviders/system/metadata.go
+++ b/internal/metadataproviders/system/metadata.go
@@ -66,13 +66,24 @@ type Provider interface {
 	HostArch() (string, error)
 
 	// HostIPs returns the host's IP interfaces
-	HostIPs() ([]net.IP, error)
+	HostIPs() ([]InterfaceIP, error)
 
 	// HostMACs returns the host's MAC addresses
-	HostMACs() ([]net.HardwareAddr, error)
+	HostMACs() ([]InterfaceMAC, error)
 
 	// CPUInfo returns the host's CPU info
 	CPUInfo(ctx context.Context) ([]cpu.InfoStat, error)
+}
+
+type InterfaceIP struct {
+    IP            net.IP
+    InterfaceName string
+}
+
+// Define a new struct for interface MACs
+type InterfaceMAC struct {
+    MAC           net.HardwareAddr
+    InterfaceName string
 }
 
 type systemMetadataProvider struct {
@@ -170,7 +181,7 @@ func (systemMetadataProvider) HostArch() (string, error) {
 	return internal.GOARCHtoHostArch(runtime.GOARCH), nil
 }
 
-func (p systemMetadataProvider) HostIPs() (ips []net.IP, err error) {
+func (p systemMetadataProvider) HostIPs() (interfaceIPs []InterfaceIP, err error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil, err
@@ -197,13 +208,16 @@ func (p systemMetadataProvider) HostIPs() (ips []net.IP, err error) {
 				continue
 			}
 
-			ips = append(ips, ip)
+			interfaceIPs = append(interfaceIPs, InterfaceIP{
+                IP:            ip,
+                InterfaceName: iface.Name,
+            })
 		}
 	}
-	return ips, err
+	return interfaceIPs, err
 }
 
-func (p systemMetadataProvider) HostMACs() (macs []net.HardwareAddr, err error) {
+func (p systemMetadataProvider) HostMACs() (interfaceMACs []InterfaceMAC, err error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil, err
@@ -214,10 +228,14 @@ func (p systemMetadataProvider) HostMACs() (macs []net.HardwareAddr, err error) 
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
 			continue
 		}
+	
+		interfaceMACs = append(interfaceMACs, InterfaceMAC{
+			MAC:           iface.HardwareAddr,
+			InterfaceName: iface.Name,
+		})
 
-		macs = append(macs, iface.HardwareAddr)
 	}
-	return macs, err
+	return interfaceMACs, err
 }
 
 func (p systemMetadataProvider) CPUInfo(ctx context.Context) ([]cpu.InfoStat, error) {

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -99,9 +99,11 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		if errIPs != nil {
 			return pcommon.NewResource(), "", fmt.Errorf("failed getting host IP addresses: %w", errIPs)
 		}
-		for _, ip := range hostIPs {
-			hostIPAttribute = append(hostIPAttribute, ip.String())
+		for _, result := range hostIPs {
+			attr := fmt.Sprintf("Interface: %s, IP: %s", result.InterfaceName, result.IP.String())
+			hostIPAttribute = append(hostIPAttribute, attr)
 		}
+	
 	}
 
 	var hostMACAttribute []any
@@ -110,8 +112,9 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		if errMACs != nil {
 			return pcommon.NewResource(), "", fmt.Errorf("failed to get host MAC addresses: %w", errMACs)
 		}
-		for _, mac := range hostMACs {
-			hostMACAttribute = append(hostMACAttribute, toIEEERA(mac))
+		for _, result := range hostMACs {
+			attr := fmt.Sprintf("Interface: %s, MAC: %s", result.InterfaceName, toIEEERA(result.MAC))
+			hostMACAttribute = append(hostMACAttribute, attr)
 		}
 	}
 

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -6,6 +6,7 @@ package system
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 
@@ -68,14 +69,14 @@ func (m *mockMetadata) ReverseLookupHost() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
-func (m *mockMetadata) HostIPs() ([]net.IP, error) {
+func (m *mockMetadata) HostIPs() ([]system.InterfaceIP, error) {
 	args := m.MethodCalled("HostIPs")
-	return args.Get(0).([]net.IP), args.Error(1)
+	return args.Get(0).([]system.InterfaceIP), args.Error(1)
 }
 
-func (m *mockMetadata) HostMACs() ([]net.HardwareAddr, error) {
+func (m *mockMetadata) HostMACs() ([]system.InterfaceMAC, error) {
 	args := m.MethodCalled("HostMACs")
-	return args.Get(0).([]net.HardwareAddr), args.Error(1)
+	return args.Get(0).([]system.InterfaceMAC), args.Error(1)
 }
 
 func (m *mockMetadata) CPUInfo(_ context.Context) ([]cpu.InfoStat, error) {
@@ -84,11 +85,23 @@ func (m *mockMetadata) CPUInfo(_ context.Context) ([]cpu.InfoStat, error) {
 }
 
 var (
-	testIPsAttribute = []any{"192.168.1.140", "fe80::abc2:4a28:737a:609e"}
-	testIPsAddresses = []net.IP{net.ParseIP(testIPsAttribute[0].(string)), net.ParseIP(testIPsAttribute[1].(string))}
+	testIPs = []system.InterfaceIP{
+		{IP: net.ParseIP("192.168.1.140"), InterfaceName: "eth0"},
+		{IP: net.ParseIP("fe80::abc2:4a28:737a:609e"), InterfaceName: "eth1"},
+	}
+	testIPsAttribute = []any{
+		fmt.Sprintf("Interface: %s, IP: %s", "eth0", "192.168.1.140"),
+		fmt.Sprintf("Interface: %s, IP: %s", "eth1", "fe80::abc2:4a28:737a:609e"),
+	}
 
-	testMACsAttribute = []any{"00-00-00-00-00-01", "DE-AD-BE-EF-00-00"}
-	testMACsAddresses = []net.HardwareAddr{{0x00, 0x00, 0x00, 0x00, 0x00, 0x01}, {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00}}
+	testMACs = []system.InterfaceMAC{
+		{MAC: net.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x01}, InterfaceName: "eth0"},
+		{MAC: net.HardwareAddr{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00}, InterfaceName: "eth1"},
+	}
+	testMACsAttribute = []any{
+		fmt.Sprintf("Interface: %s, MAC: %s", "eth0", "00-00-00-00-00-01"),
+		fmt.Sprintf("Interface: %s, MAC: %s", "eth1", "DE-AD-BE-EF-00-00"),
+	}
 )
 
 func TestNewDetector(t *testing.T) {
@@ -124,11 +137,11 @@ func TestToIEEERA(t *testing.T) {
 		expected string
 	}{
 		{
-			addr:     testMACsAddresses[0],
+			addr:      testMACs[0].MAC,
 			expected: testMACsAttribute[0].(string),
 		},
 		{
-			addr:     testMACsAddresses[1],
+			addr:     testMACs[1].MAC,
 			expected: testMACsAttribute[1].(string),
 		},
 	}
@@ -157,8 +170,8 @@ func TestDetectFQDNAvailable(t *testing.T) {
 	md.On("OSType").Return("darwin", nil)
 	md.On("HostID").Return("2", nil)
 	md.On("HostArch").Return("amd64", nil)
-	md.On("HostIPs").Return(testIPsAddresses, nil)
-	md.On("HostMACs").Return(testMACsAddresses, nil)
+	md.On("HostIPs").Return(testIPs, nil)
+	md.On("HostMACs").Return(testMACs, nil)
 
 	detector := newTestDetector(md, []string{"dns"}, allEnabledConfig())
 	res, schemaURL, err := detector.Detect(context.Background())
@@ -212,8 +225,8 @@ func TestEnableHostID(t *testing.T) {
 	mdHostname.On("OSType").Return("darwin", nil)
 	mdHostname.On("HostID").Return("3", nil)
 	mdHostname.On("HostArch").Return("amd64", nil)
-	mdHostname.On("HostIPs").Return(testIPsAddresses, nil)
-	mdHostname.On("HostMACs").Return(testMACsAddresses, nil)
+	mdHostname.On("HostIPs").Return(testIPs, nil)
+	mdHostname.On("HostMACs").Return(testMACs, nil)
 
 	detector := newTestDetector(mdHostname, []string{"dns", "os"}, allEnabledConfig())
 	res, schemaURL, err := detector.Detect(context.Background())
@@ -241,8 +254,8 @@ func TestUseHostname(t *testing.T) {
 	mdHostname.On("OSType").Return("darwin", nil)
 	mdHostname.On("HostID").Return("1", nil)
 	mdHostname.On("HostArch").Return("amd64", nil)
-	mdHostname.On("HostIPs").Return(testIPsAddresses, nil)
-	mdHostname.On("HostMACs").Return(testMACsAddresses, nil)
+	mdHostname.On("HostIPs").Return(testIPs, nil)
+	mdHostname.On("HostMACs").Return(testMACs, nil)
 
 	detector := newTestDetector(mdHostname, []string{"os"}, allEnabledConfig())
 	res, schemaURL, err := detector.Detect(context.Background())
@@ -272,8 +285,8 @@ func TestDetectError(t *testing.T) {
 	mdFQDN.On("Hostname").Return("", errors.New("err"))
 	mdFQDN.On("HostID").Return("", errors.New("err"))
 	mdFQDN.On("HostArch").Return("amd64", nil)
-	mdFQDN.On("HostIPs").Return(testIPsAddresses, nil)
-	mdFQDN.On("HostMACs").Return(testMACsAddresses, nil)
+	mdFQDN.On("HostIPs").Return(testIPs, nil)
+	mdFQDN.On("HostMACs").Return(testMACs, nil)
 
 	detector := newTestDetector(mdFQDN, []string{"dns"}, allEnabledConfig())
 	res, schemaURL, err := detector.Detect(context.Background())
@@ -288,8 +301,8 @@ func TestDetectError(t *testing.T) {
 	mdHostname.On("Hostname").Return("", errors.New("err"))
 	mdHostname.On("HostID").Return("", errors.New("err"))
 	mdHostname.On("HostArch").Return("amd64", nil)
-	mdHostname.On("HostIPs").Return(testIPsAddresses, nil)
-	mdHostname.On("HostMACs").Return(testMACsAddresses, nil)
+	mdHostname.On("HostIPs").Return(testIPs, nil)
+	mdHostname.On("HostMACs").Return(testMACs, nil)
 
 	detector = newTestDetector(mdHostname, []string{"os"}, allEnabledConfig())
 	res, schemaURL, err = detector.Detect(context.Background())
@@ -304,7 +317,7 @@ func TestDetectError(t *testing.T) {
 	mdOSType.On("OSType").Return("", errors.New("err"))
 	mdOSType.On("HostID").Return("1", nil)
 	mdOSType.On("HostArch").Return("amd64", nil)
-	mdOSType.On("HostIPs").Return(testIPsAddresses, nil)
+	mdOSType.On("HostIPs").Return(testIPs, nil)
 
 	detector = newTestDetector(mdOSType, []string{"os"}, allEnabledConfig())
 	res, schemaURL, err = detector.Detect(context.Background())
@@ -319,8 +332,8 @@ func TestDetectError(t *testing.T) {
 	mdHostID.On("OSType").Return("linux", nil)
 	mdHostID.On("HostID").Return("", errors.New("err"))
 	mdHostID.On("HostArch").Return("arm64", nil)
-	mdHostID.On("HostIPs").Return(testIPsAddresses, nil)
-	mdHostID.On("HostMACs").Return(testMACsAddresses, nil)
+	mdHostID.On("HostIPs").Return(testIPs, nil)
+	mdHostID.On("HostMACs").Return(testMACs, nil)
 
 	detector = newTestDetector(mdHostID, []string{"os"}, allEnabledConfig())
 	res, schemaURL, err = detector.Detect(context.Background())
@@ -343,8 +356,8 @@ func TestDetectCPUInfo(t *testing.T) {
 	md.On("OSType").Return("darwin", nil)
 	md.On("HostID").Return("2", nil)
 	md.On("HostArch").Return("amd64", nil)
-	md.On("HostIPs").Return(testIPsAddresses, nil)
-	md.On("HostMACs").Return(testMACsAddresses, nil)
+	md.On("HostIPs").Return(testIPs, nil)
+	md.On("HostMACs").Return(testMACs, nil)
 	md.On("CPUInfo").Return([]cpu.InfoStat{{Family: "some"}}, nil)
 
 	cfg := allEnabledConfig()
@@ -355,6 +368,7 @@ func TestDetectCPUInfo(t *testing.T) {
 	assert.Equal(t, conventions.SchemaURL, schemaURL)
 	md.AssertExpectations(t)
 
+	fmt.Println("res.Attributes().AsRaw()", res.Attributes().AsRaw())
 	expected := map[string]any{
 		conventions.AttributeHostName:      "fqdn",
 		conventions.AttributeOSDescription: "Ubuntu 22.04.2 LTS (Jammy Jellyfish)",

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -137,12 +137,12 @@ func TestToIEEERA(t *testing.T) {
 		expected string
 	}{
 		{
-			addr:      testMACs[0].MAC,
-			expected: testMACsAttribute[0].(string),
+			addr:     net.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			expected: "00-00-00-00-00-01",
 		},
 		{
-			addr:     testMACs[1].MAC,
-			expected: testMACsAttribute[1].(string),
+			addr:     net.HardwareAddr{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00},
+			expected: "DE-AD-BE-EF-00-00",
 		},
 	}
 

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -368,7 +368,6 @@ func TestDetectCPUInfo(t *testing.T) {
 	assert.Equal(t, conventions.SchemaURL, schemaURL)
 	md.AssertExpectations(t)
 
-	fmt.Println("res.Attributes().AsRaw()", res.Attributes().AsRaw())
 	expected := map[string]any{
 		conventions.AttributeHostName:      "fqdn",
 		conventions.AttributeOSDescription: "Ubuntu 22.04.2 LTS (Jammy Jellyfish)",


### PR DESCRIPTION
host.arch	amd64
host.cpu.family	6
host.cpu.model.id	140
host.cpu.model.name	11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
host.cpu.stepping	1
host.cpu.vendor.id	GenuineIntel
host.id	naman-Vostro-3500
host.ip	["Interface: wlp2s0, IP: 192.168.4.148","Interface: wlp2s0, IP: fe80::1e97:32e2:db54:91a7","Interface: br-227c46af4f25, IP: 172.18.0.1","Interface: br-227c46af4f25, IP: fc00:f853:ccd:e793::1","Interface: br-227c46af4f25, IP: fe80::543a:37ff:fe6c:7d9b","Interface: br-2cb2aeed7aab, IP: 172.20.0.1","Interface: docker0, IP: 172.17.0.1","Interface: br-7fb2c6b1fc13, IP: 192.168.49.1","Interface: br-8681ab5a3d71, IP: 172.19.0.1"]
host.mac	["Interface: enp1s0, MAC: 60-18-95-1C-8C-E9","Interface: wlp2s0, MAC: D4-1B-81-CA-09-41","Interface: br-227c46af4f25, MAC: 56-3A-37-6C-7D-9B","Interface: br-2cb2aeed7aab, MAC: B6-64-62-28-C9-C1","Interface: docker0, MAC: E2-9D-3E-78-AE-3C","Interface: br-7fb2c6b1fc13, MAC: 62-4D-EB-98-70-6D","Interface: br-8681ab5a3d71, MAC: B6-77-BE-CF-92-B8"]
host.name	naman-Vostro-3500
os.description	Ubuntu 24.04.2 LTS (Noble Numbat) (Linux naman-Vostro-3500 6.11.0-21-generic #21~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Feb 24 16:52:15 UTC 2 x86_64)
os.type	linux