### PR TITLE
Add severity detection parser to detect log severity from log body

### DIFF
--- a/pkg/stanza/adapter/register.go
+++ b/pkg/stanza/adapter/register.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/scope"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/severity"
+	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/severitydetect"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/syslog"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/time"
 	_ "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/trace"

--- a/pkg/stanza/operator/helper/parser.go
+++ b/pkg/stanza/operator/helper/parser.go
@@ -25,15 +25,16 @@ func NewParserConfig(operatorID, operatorType string) ParserConfig {
 
 // ParserConfig provides the basic implementation of a parser config.
 type ParserConfig struct {
-	TransformerConfig `mapstructure:",squash"`
-	ParseFrom         entry.Field         `mapstructure:"parse_from"`
-	ParseTo           entry.RootableField `mapstructure:"parse_to"`
-	BodyField         *entry.Field        `mapstructure:"body"`
-	TimeParser        *TimeParser         `mapstructure:"timestamp,omitempty"`
-	SeverityConfig    *SeverityConfig     `mapstructure:"severity,omitempty"`
-	TraceParser       *TraceParser        `mapstructure:"trace,omitempty"`
-	ScopeNameParser   *ScopeNameParser    `mapstructure:"scope_name,omitempty"`
-	Flatten           bool                `mapstructure:"flatten"`
+	TransformerConfig       `mapstructure:",squash"`
+	ParseFrom               entry.Field              `mapstructure:"parse_from"`
+	ParseTo                 entry.RootableField      `mapstructure:"parse_to"`
+	BodyField               *entry.Field             `mapstructure:"body"`
+	TimeParser              *TimeParser              `mapstructure:"timestamp,omitempty"`
+	SeverityConfig          *SeverityConfig          `mapstructure:"severity,omitempty"`
+	TraceParser             *TraceParser             `mapstructure:"trace,omitempty"`
+	ScopeNameParser         *ScopeNameParser         `mapstructure:"scope_name,omitempty"`
+	Flatten                 bool                     `mapstructure:"flatten"`
+	SeverityDetectionConfig *SeverityDetectionConfig `mapstructure:"severity_detection,omitempty"`
 }
 
 // Build will build a parser operator.
@@ -81,20 +82,28 @@ func (c ParserConfig) Build(set component.TelemetrySettings) (ParserOperator, er
 		parserOperator.ScopeNameParser = c.ScopeNameParser
 	}
 
+	if c.SeverityDetectionConfig != nil {
+		severityDetectionParser, err := c.SeverityDetectionConfig.Build(set)
+		if err != nil {
+			return ParserOperator{}, err
+		}
+		parserOperator.SeverityDetectionParser = &severityDetectionParser
+	}
 	return parserOperator, nil
 }
 
 // ParserOperator provides a basic implementation of a parser operator.
 type ParserOperator struct {
 	TransformerOperator
-	ParseFrom       entry.Field
-	ParseTo         entry.Field
-	BodyField       *entry.Field
-	TimeParser      *TimeParser
-	SeverityParser  *SeverityParser
-	TraceParser     *TraceParser
-	ScopeNameParser *ScopeNameParser
-	Flatten         bool
+	ParseFrom               entry.Field
+	ParseTo                 entry.Field
+	BodyField               *entry.Field
+	TimeParser              *TimeParser
+	SeverityParser          *SeverityParser
+	TraceParser             *TraceParser
+	ScopeNameParser         *ScopeNameParser
+	Flatten                 bool
+	SeverityDetectionParser *SeverityDetectionParser
 }
 
 // ProcessWith will run ParseWith on the entry, then forward the entry on to the next operators.

--- a/pkg/stanza/operator/helper/severity_detect.go
+++ b/pkg/stanza/operator/helper/severity_detect.go
@@ -1,0 +1,88 @@
+package helper
+
+// pkg/stanza/operator/helper/severity_detection.go
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
+)
+
+// SeverityDetectionParser is a helper that detects severity by analyzing the log body content
+type SeverityDetectionParser struct {
+	Mapping       severityMap
+	overwriteText bool
+}
+
+// Parse will analyze the log body for severity indicators and set the entry severity accordingly
+func (p *SeverityDetectionParser) Parse(ent *entry.Entry) error {
+	if ent.Body == nil {
+		return errors.NewError(
+			"log entry does not have a body field",
+			"ensure that all entries forwarded to this parser contain a body field",
+		)
+	}
+
+	bodyStr, ok := ent.Body.(string)
+	if !ok {
+		return errors.NewError(
+			"log entry body is not a string",
+			"ensure that the body field contains string content",
+		)
+	}
+
+	if ent.SeverityText != "" {
+		ent.SeverityText = strings.ToUpper(ent.SeverityText)
+		return nil
+	}
+
+	// If the severity is already set, don't override it
+	if ent.Severity != entry.Default {
+		return nil
+	}
+
+	// Convert body to lowercase for case-insensitive matching
+	bodyLower := strings.ToLower(bodyStr)
+
+	// Find the first matching severity from the mapping
+	var matchedSeverity entry.Severity
+	var matchedText string
+	var found bool
+
+	// Check each pattern in the mapping
+	for pattern, sev := range p.Mapping {
+		// Create a regex pattern that matches the word with word boundaries
+		wordPattern := fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta(strings.ToLower(pattern)))
+		matched, err := regexp.MatchString(wordPattern, bodyLower)
+		if err != nil {
+			return errors.NewError(
+				"failed to compile regex pattern",
+				"check the severity mapping patterns",
+				"pattern", pattern,
+				"error", err.Error(),
+			)
+		}
+		if matched {
+			matchedSeverity = sev
+			matchedText = pattern
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		matchedSeverity = entry.Info
+		matchedText = "INFO"
+	}
+
+	ent.Severity = matchedSeverity
+	if p.overwriteText {
+		ent.SeverityText = matchedSeverity.String()
+	} else {
+		ent.SeverityText = matchedText
+	}
+
+	return nil
+}

--- a/pkg/stanza/operator/helper/severity_detect_test.go
+++ b/pkg/stanza/operator/helper/severity_detect_test.go
@@ -1,0 +1,242 @@
+// pkg/stanza/operator/helper/severity_detect_test.go
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+)
+
+type severityDetectionTestCase struct {
+	name          string
+	body          string
+	mapping       map[string]any
+	expected      entry.Severity
+	expectedText  string
+	overwriteText bool
+	parseErr      bool
+}
+
+func TestSeverityDetectionParser(t *testing.T) {
+	testCases := []severityDetectionTestCase{
+		{
+			name: "simple_error_match",
+			body: "This is an error message",
+			mapping: map[string]any{
+				"error": "error",
+			},
+			expected:     entry.Error,
+			expectedText: "error",
+		},
+		{
+			name: "case_insensitive_match",
+			body: "This is an ERROR message",
+			mapping: map[string]any{
+				"error": "error",
+			},
+			expected:     entry.Error,
+			expectedText: "error",
+		},
+		{
+			name: "overwrite_text",
+			body: "This is an ERROR message",
+			mapping: map[string]any{
+				"error": "error",
+			},
+			expected:      entry.Error,
+			expectedText:  "ERROR",
+			overwriteText: true,
+		},
+		{
+			name: "multiple_patterns_first_match",
+			body: "Warning: This could be dangerous",
+			mapping: map[string]any{
+				"error":   "error",
+				"warn":    "warning",
+				"info":    "info",
+				"debug":   "debug",
+				"fatal":   "fatal",
+				"panic":   "panic",
+				"trace":   "trace",
+				"verbose": "verbose",
+			},
+			expected:     entry.Warn,
+			expectedText: "warn",
+		},
+		{
+			name: "no_match",
+			body: "This is a regular message",
+			mapping: map[string]any{
+				"error": "error",
+				"warn":  "warning",
+			},
+			expected:     entry.Default,
+			expectedText: "",
+		},
+		{
+			name: "empty_body",
+			body: "",
+			mapping: map[string]any{
+				"error": "error",
+			},
+			expected:     entry.Default,
+			expectedText: "",
+		},
+		{
+			name: "multiple_severity_words",
+			body: "Error occurred: Fatal system crash",
+			mapping: map[string]any{
+				"error": "error",
+				"fatal": "fatal",
+			},
+			expected:     entry.Error, // Should match first occurrence
+			expectedText: "error",
+		},
+		{
+			name: "partial_word_match",
+			body: "Errorless operation completed",
+			mapping: map[string]any{
+				"error": "error",
+			},
+			expected:     entry.Error,
+			expectedText: "error",
+		},
+		{
+			name:     "nil_body",
+			body:     "", // Will be set to nil in test
+			mapping:  map[string]any{"error": "error"},
+			parseErr: true,
+		},
+		{
+			name: "custom_severity_levels",
+			body: "CRITICAL: System failure",
+			mapping: map[string]any{
+				"error2":   "critical",
+				"warning3": "warning",
+			},
+			expected:     entry.Error2,
+			expectedText: "critical",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &SeverityConfig{
+				Mapping:       tc.mapping,
+				OverwriteText: tc.overwriteText,
+			}
+
+			set := componenttest.NewNopTelemetrySettings()
+			parser, err := cfg.Build(set)
+			require.NoError(t, err, "failed to build severity parser")
+
+			ent := entry.New()
+			if tc.body != "" {
+				ent.Body = tc.body
+			}
+
+			err = parser.Parse(ent)
+
+			if tc.parseErr {
+				require.Error(t, err, "expected error when parsing")
+				return
+			}
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, ent.Severity)
+			if tc.overwriteText {
+				require.Equal(t, tc.expectedText, ent.SeverityText)
+			} else if tc.expected != entry.Default {
+				require.Equal(t, tc.expectedText, ent.SeverityText)
+			}
+		})
+	}
+}
+
+func TestSeverityDetectionWithInvalidBody(t *testing.T) {
+	cfg := &SeverityConfig{
+		Mapping: map[string]any{
+			"error": "error",
+		},
+	}
+
+	set := componenttest.NewNopTelemetrySettings()
+	parser, err := cfg.Build(set)
+	require.NoError(t, err, "failed to build severity parser")
+
+	ent := entry.New()
+	ent.Body = 123 // Non-string body
+
+	err = parser.Parse(ent)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "log entry body is not a string")
+}
+
+func TestSeverityDetectionWithComplexMapping(t *testing.T) {
+	complexMapping := map[string]any{
+		"fatal4": []any{"critical", "panic", "fatal"},
+		"error3": []any{"error", "failed", "failure"},
+		"warn2":  []any{"warning", "warn"},
+		"info":   []any{"info", "notice"},
+		"debug":  []any{"debug", "trace"},
+	}
+
+	testCases := []struct {
+		name     string
+		body     string
+		expected entry.Severity
+	}{
+		{
+			name:     "match_fatal",
+			body:     "PANIC: System is down",
+			expected: entry.Fatal4,
+		},
+		{
+			name:     "match_error",
+			body:     "Operation FAILED",
+			expected: entry.Error3,
+		},
+		{
+			name:     "match_warning",
+			body:     "Warning: Resource usage high",
+			expected: entry.Warn2,
+		},
+		{
+			name:     "match_info",
+			body:     "Notice: Backup completed",
+			expected: entry.Info,
+		},
+		{
+			name:     "match_debug",
+			body:     "Debug: Connection attempt",
+			expected: entry.Debug,
+		},
+		{
+			name:     "no_match",
+			body:     "Regular message",
+			expected: entry.Default,
+		},
+	}
+
+	cfg := &SeverityConfig{
+		Mapping: complexMapping,
+	}
+
+	set := componenttest.NewNopTelemetrySettings()
+	parser, err := cfg.Build(set)
+	require.NoError(t, err, "failed to build severity parser")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ent := entry.New()
+			ent.Body = tc.body
+
+			err = parser.Parse(ent)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ent.Severity)
+		})
+	}
+}

--- a/pkg/stanza/operator/helper/severity_detection_builder.go
+++ b/pkg/stanza/operator/helper/severity_detection_builder.go
@@ -1,0 +1,126 @@
+// pkg/stanza/operator/helper/severity_detection_builder.go
+package helper
+
+import (
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+)
+
+// NewSeverityDetectionConfig creates a new severity detection parser config
+func NewSeverityDetectionConfig() SeverityDetectionConfig {
+	return SeverityDetectionConfig{}
+}
+
+// SeverityDetectionConfig allows users to specify how to detect severity from log body content
+type SeverityDetectionConfig struct {
+	Preset        string         `mapstructure:"preset,omitempty"`
+	Mapping       map[string]any `mapstructure:"mapping,omitempty"`
+	OverwriteText bool           `mapstructure:"overwrite_text,omitempty"`
+}
+
+// Build builds a SeverityDetectionParser from a SeverityDetectionConfig
+func (c *SeverityDetectionConfig) Build(_ component.TelemetrySettings) (SeverityDetectionParser, error) {
+	operatorMapping := getSeverityDetectionMapping(c.Preset)
+
+	if len(c.Mapping) > 0 {
+		for severity, unknown := range c.Mapping {
+			sev, err := validateSeverity(severity)
+			if err != nil {
+				return SeverityDetectionParser{}, err
+			}
+
+			switch u := unknown.(type) {
+			case []any: // handle array of patterns
+				for _, value := range u {
+					patterns, err := parseDetectionPatterns(value)
+					if err != nil {
+						return SeverityDetectionParser{}, err
+					}
+					for _, pattern := range patterns {
+						operatorMapping.add(sev, pattern)
+					}
+				}
+			case any:
+				patterns, err := parseDetectionPatterns(u)
+				if err != nil {
+					return SeverityDetectionParser{}, err
+				}
+				for _, pattern := range patterns {
+					operatorMapping.add(sev, pattern)
+				}
+			}
+		}
+
+		if c.Preset == "default" {
+			defaultMapping := getSeverityDetectionMapping("default")
+			for k, v := range defaultMapping {
+				operatorMapping.add(v, k)
+			}
+		}
+	} else {
+		operatorMapping = getSeverityDetectionMapping("default")
+	}
+
+	p := SeverityDetectionParser{
+		Mapping:       operatorMapping,
+		overwriteText: c.OverwriteText,
+	}
+
+	return p, nil
+}
+
+// parseDetectionPatterns converts various input types into string patterns for matching
+func parseDetectionPatterns(value any) ([]string, error) {
+	switch v := value.(type) {
+	case string:
+		// Handle HTTP status code ranges
+		return []string{strings.ToLower(v)}, nil
+
+	case []byte:
+		return []string{strings.ToLower(string(v))}, nil
+	case int:
+		return []string{fmt.Sprintf("%d", v)}, nil
+	case float64:
+		if v != float64(int(v)) {
+			return nil, fmt.Errorf("floating-point numbers must be whole numbers, got %f", v)
+		}
+		return []string{fmt.Sprintf("%d", int(v))}, nil
+	default:
+		return nil, fmt.Errorf("type %T cannot be used as a detection pattern", v)
+	}
+}
+
+// getDefaultDetectionMapping returns a set of common patterns for severity detection
+func getDefaultDetectionMapping() severityMap {
+	return severityMap{
+		"panic":     entry.Fatal,
+		"fatal":     entry.Fatal,
+		"emerg":     entry.Fatal,
+		"emergency": entry.Fatal,
+		"alert":     entry.Fatal,
+		"critical":  entry.Fatal,
+		"crit":      entry.Fatal,
+		"error":     entry.Error,
+		"err":       entry.Error,
+		"warning":   entry.Warn,
+		"warn":      entry.Warn,
+		"notice":    entry.Info,
+		"info":      entry.Info,
+		"debug":     entry.Debug,
+		"trace":     entry.Trace,
+	}
+}
+
+func getSeverityDetectionMapping(preset string) severityMap {
+
+	switch preset {
+	case "default":
+		return getDefaultDetectionMapping()
+	default:
+		return severityMap{}
+	}
+}

--- a/pkg/stanza/operator/helper/severity_detection_builder.go
+++ b/pkg/stanza/operator/helper/severity_detection_builder.go
@@ -17,9 +17,10 @@ func NewSeverityDetectionConfig() SeverityDetectionConfig {
 
 // SeverityDetectionConfig allows users to specify how to detect severity from log body content
 type SeverityDetectionConfig struct {
-	Preset        string         `mapstructure:"preset,omitempty"`
-	Mapping       map[string]any `mapstructure:"mapping,omitempty"`
-	OverwriteText bool           `mapstructure:"overwrite_text,omitempty"`
+	Preset                 string         `mapstructure:"preset,omitempty"`
+	Mapping                map[string]any `mapstructure:"mapping,omitempty"`
+	OverwriteText          bool           `mapstructure:"overwrite_text,omitempty"`
+	MultiMatchHighSeverity bool           `mapstructure:"multi_match_high_severity,omitempty"`
 }
 
 // Build builds a SeverityDetectionParser from a SeverityDetectionConfig
@@ -66,8 +67,9 @@ func (c *SeverityDetectionConfig) Build(_ component.TelemetrySettings) (Severity
 	}
 
 	p := SeverityDetectionParser{
-		Mapping:       operatorMapping,
-		overwriteText: c.OverwriteText,
+		Mapping:                operatorMapping,
+		overwriteText:          c.OverwriteText,
+		multiMatchHighSeverity: c.MultiMatchHighSeverity,
 	}
 
 	return p, nil

--- a/pkg/stanza/operator/parser/json/config.go
+++ b/pkg/stanza/operator/parser/json/config.go
@@ -4,7 +4,6 @@
 package json // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/json"
 
 import (
-	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"

--- a/pkg/stanza/operator/parser/severitydetect/README.md
+++ b/pkg/stanza/operator/parser/severitydetect/README.md
@@ -1,0 +1,192 @@
+// pkg/stanza/operator/parser/severity_detect/README.md
+# Severity Detection Parser Operator
+
+The `severity_detect_parser` operator parses severity levels from log messages by scanning the body content for known patterns.
+
+## Configuration Fields
+
+| Field         | Default          | Description |
+|---------------|------------------|-------------|
+| `id`          | `severity_detect_parser` | A unique identifier for the operator. |
+| `type`        | `severity_detect_parser` | The operator type. |
+| `output`      | Next operator    | The connected operator(s) that will receive all outbound entries. |
+| `on_error`    | `send`          | The behavior of the operator if it encounters an error. See [on_error](../../types/on_error.md). |
+| `preset`      | `""`            | A predefined set of severity mappings. Available options: "detection". |
+| `mapping`     | `{}`            | A map of severity levels to pattern lists. |
+| `overwrite_text` | `false`      | If true, overwrites the severity text with the standard severity level string. |
+
+## Examples
+
+### Basic Configuration
+```yaml
+- type: severity_detect_parser
+  preset: detection
+```
+
+### Custom Pattern Mapping
+```yaml
+- type: severity_detect_parser
+  mapping:
+    error:
+      - "exception"
+      - "failed"
+      - "error occurred"
+    warn:
+      - "warning:"
+      - "attention required"
+    info:
+      - "success"
+      - "completed"
+  overwrite_text: true
+```
+```
+
+4. Add example configuration to the filelog receiver's examples:
+
+```yaml
+# examples/filelog/config.yaml
+receivers:
+  filelog:
+    operators:
+      - type: severity_detect_parser
+        preset: detection
+```
+
+5. Add tests for the filelog receiver integration:
+
+```go
+// pkg/stanza/operator/parser/severity_detect/integration_test.go
+package severity_detect
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+)
+
+func TestSeverityDetectIntegration(t *testing.T) {
+	cases := []struct {
+		name           string
+		config         *Config
+		inputLogs      []string
+		expectedLevels []plog.SeverityNumber
+	}{
+		{
+			name: "DefaultPreset",
+			config: func() *Config {
+				cfg := NewConfig()
+				cfg.Preset = "detection"
+				return cfg
+			}(),
+			inputLogs: []string{
+				"ERROR: System failure",
+				"WARNING: Disk space low",
+				"INFO: Operation completed",
+			},
+			expectedLevels: []plog.SeverityNumber{
+				plog.SeverityNumberError,
+				plog.SeverityNumberWarn,
+				plog.SeverityNumberInfo,
+			},
+		},
+		{
+			name: "CustomMapping",
+			config: func() *Config {
+				cfg := NewConfig()
+				cfg.Mapping = map[string]any{
+					"error": []any{"failure", "exception"},
+					"warn":  "attention",
+				}
+				return cfg
+			}(),
+			inputLogs: []string{
+				"System failure detected",
+				"Attention required",
+				"Normal operation",
+			},
+			expectedLevels: []plog.SeverityNumber{
+				plog.SeverityNumberError,
+				plog.SeverityNumberWarn,
+				plog.SeverityNumberUnspecified,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op, err := tc.config.Build(componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			mockOutput := testutil.NewMockOperator("mock")
+			op.SetOutputOperators([]operator.Operator{mockOutput})
+
+			for i, logLine := range tc.inputLogs {
+				entry := entry.New()
+				entry.Timestamp = time.Now()
+				entry.Body = logLine
+
+				err = op.Process(context.Background(), entry)
+				require.NoError(t, err)
+
+				logs := mockOutput.Received()
+				require.Equal(t, tc.expectedLevels[i], mapSeverityToPlog(logs[i].Severity))
+			}
+		})
+	}
+}
+
+func mapSeverityToPlog(sev entry.Severity) plog.SeverityNumber {
+	switch sev {
+	case entry.Fatal, entry.Fatal2, entry.Fatal3, entry.Fatal4:
+		return plog.SeverityNumberFatal
+	case entry.Error, entry.Error2, entry.Error3, entry.Error4:
+		return plog.SeverityNumberError
+	case entry.Warn, entry.Warn2, entry.Warn3, entry.Warn4:
+		return plog.SeverityNumberWarn
+	case entry.Info, entry.Info2, entry.Info3, entry.Info4:
+		return plog.SeverityNumberInfo
+	case entry.Debug, entry.Debug2, entry.Debug3, entry.Debug4:
+		return plog.SeverityNumberDebug
+	case entry.Trace, entry.Trace2, entry.Trace3, entry.Trace4:
+		return plog.SeverityNumberTrace
+	default:
+		return plog.SeverityNumberUnspecified
+	}
+}
+```
+
+6. Update the module's `go.mod` to ensure all dependencies are properly included:
+
+```go
+// go.mod
+require (
+    // ... existing requirements ...
+    go.opentelemetry.io/collector/pdata v1.0.0
+    // ... other requirements ...
+)
+```
+
+These changes will:
+1. Properly integrate the severity detection parser with the filelog receiver
+2. Provide documentation and examples for users
+3. Ensure the operator is properly registered and available
+4. Add integration tests to verify the operator works with the OpenTelemetry logging pipeline
+5. Map severity levels correctly to OpenTelemetry's severity numbers
+
+The key aspects we've addressed are:
+- Proper package naming and organization
+- Registration with the operator system
+- Documentation and examples
+- Integration testing
+- Severity level mapping to OpenTelemetry format
+- Configuration compatibility
+
+Would you like me to explain any of these changes in more detail?

--- a/pkg/stanza/operator/parser/severitydetect/config.go
+++ b/pkg/stanza/operator/parser/severitydetect/config.go
@@ -1,0 +1,52 @@
+// pkg/stanza/operator/parser/severitydetect/config.go
+package severitydetect
+
+import (
+	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+)
+
+const operatorType = "severity_detection_parser"
+
+func init() {
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
+}
+
+// NewConfig creates a new severity detection parser config with default values
+func NewConfig() *Config {
+	return NewConfigWithID(operatorType)
+}
+
+// NewConfigWithID creates a new severity detection parser config with default values
+func NewConfigWithID(operatorID string) *Config {
+	return &Config{
+		TransformerConfig:       helper.NewTransformerConfig(operatorID, operatorType),
+		SeverityDetectionConfig: helper.NewSeverityDetectionConfig(),
+	}
+}
+
+// Config is the configuration of a severity detection parser operator.
+type Config struct {
+	helper.TransformerConfig       `mapstructure:",squash"`
+	helper.SeverityDetectionConfig `mapstructure:",omitempty,squash"`
+}
+
+// Build will build a severity detection parser operator.
+func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
+	if err != nil {
+		return nil, err
+	}
+
+	severityParser, err := c.SeverityDetectionConfig.Build(set)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Parser{
+		TransformerOperator:     transformerOperator,
+		SeverityDetectionParser: severityParser,
+	}, nil
+}

--- a/pkg/stanza/operator/parser/severitydetect/config_test.go
+++ b/pkg/stanza/operator/parser/severitydetect/config_test.go
@@ -1,0 +1,61 @@
+// pkg/stanza/operator/parser/severitydetect/config_test.go
+package severitydetect
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
+)
+
+func TestUnmarshal(t *testing.T) {
+	operatortest.ConfigUnmarshalTests{
+		DefaultConfig: NewConfig(),
+		TestsFile:     filepath.Join(".", "testdata", "config.yaml"),
+		Tests: []operatortest.ConfigUnmarshalTest{
+			{
+				Name:   "default",
+				Expect: NewConfig(),
+			},
+			{
+				Name: "on_error_drop",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.OnError = "drop"
+					return cfg
+				}(),
+			},
+			{
+				Name: "parse_with_preset",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.Preset = "detection"
+					return cfg
+				}(),
+			},
+			{
+				Name: "custom_mapping",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.Mapping = map[string]any{
+						"error": []any{"exception", "failed"},
+						"warn":  []any{"warning:", "attention"},
+						"info":  []any{"success", "completed"},
+					}
+					return cfg
+				}(),
+			},
+			{
+				Name: "overwrite_text",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.OverwriteText = true
+					cfg.Mapping = map[string]any{
+						"error": "error occurred",
+					}
+					return cfg
+				}(),
+			},
+		},
+	}.Run(t)
+}

--- a/pkg/stanza/operator/parser/severitydetect/package_test.go
+++ b/pkg/stanza/operator/parser/severitydetect/package_test.go
@@ -1,0 +1,12 @@
+// pkg/stanza/operator/parser/severitydetect/package_test.go
+package severitydetect
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/stanza/operator/parser/severitydetect/parser.go
+++ b/pkg/stanza/operator/parser/severitydetect/parser.go
@@ -1,0 +1,20 @@
+// pkg/stanza/operator/parser/severitydetect/parser.go
+package severitydetect
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+)
+
+// Parser is an operator that parses severity by detecting patterns in the log body.
+type Parser struct {
+	helper.TransformerOperator
+	helper.SeverityDetectionParser
+}
+
+// Process will parse severity from an entry's body.
+func (p *Parser) Process(ctx context.Context, entry *entry.Entry) error {
+	return p.ProcessWith(ctx, entry, p.Parse)
+}

--- a/pkg/stanza/operator/parser/severitydetect/parser_test.go
+++ b/pkg/stanza/operator/parser/severitydetect/parser_test.go
@@ -1,0 +1,118 @@
+// pkg/stanza/operator/parser/severitydetect/parser_test.go
+package severitydetect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+)
+
+func TestSeverityDetectionParser(t *testing.T) {
+	testCases := []struct {
+		name          string
+		body          string
+		mapping       map[string]any
+		preset        string
+		expected      entry.Severity
+		expectedText  string
+		overwriteText bool
+	}{
+		{
+			name: "simple_error",
+			body: "An error occurred in the system",
+			mapping: map[string]any{
+				"error": "error",
+			},
+			expected:     entry.Error,
+			expectedText: "error",
+		},
+		{
+			name: "case_insensitive",
+			body: "ERROR: System failure",
+			mapping: map[string]any{
+				"error": "error",
+			},
+			expected:     entry.Error,
+			expectedText: "error",
+		},
+		{
+			name: "multiple_patterns",
+			body: "Warning: Resource usage high",
+			mapping: map[string]any{
+				"error": []any{"error", "exception"},
+				"warn":  []any{"warning", "attention"},
+			},
+			expected:     entry.Warn,
+			expectedText: "warning",
+		},
+		{
+			name:          "preset_detection",
+			body:          "CRITICAL: Database connection lost",
+			preset:        "detection",
+			expected:      entry.Fatal3,
+			expectedText:  "CRITICAL",
+			overwriteText: true,
+		},
+		{
+			name: "http_status",
+			body: "Request failed with status 404",
+			mapping: map[string]any{
+				"error": "404",
+			},
+			expected:     entry.Error,
+			expectedText: "404",
+		},
+		{
+			name: "no_match",
+			body: "Everything is running smoothly",
+			mapping: map[string]any{
+				"error": []any{"error", "failure"},
+			},
+			expected:     entry.Default,
+			expectedText: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewConfigWithID("test")
+			cfg.Mapping = tc.mapping
+			cfg.Preset = tc.preset
+			cfg.OverwriteText = tc.overwriteText
+
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(set)
+			require.NoError(t, err)
+
+			mockOutput := &testutil.Operator{}
+			resultChan := make(chan *entry.Entry, 1)
+			mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				resultChan <- args.Get(1).(*entry.Entry)
+			}).Return(nil)
+
+			parser := op.(*Parser)
+			parser.OutputOperators = []operator.Operator{mockOutput}
+
+			entry := entry.New()
+			entry.Body = tc.body
+
+			err = parser.Parse(entry)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, entry.Severity)
+			if tc.expectedText != "" {
+				if tc.overwriteText {
+					require.Equal(t, tc.expected.String(), entry.SeverityText)
+				} else {
+					require.Equal(t, tc.expectedText, entry.SeverityText)
+				}
+			}
+		})
+	}
+}

--- a/pkg/stanza/operator/parser/severitydetect/testdata/config.yaml
+++ b/pkg/stanza/operator/parser/severitydetect/testdata/config.yaml
@@ -1,0 +1,26 @@
+# pkg/stanza/operator/parser/severitydetect/testdata/config.yaml
+default:
+  type: severity_detection_parser
+on_error_drop:
+  type: severity_detection_parser
+  on_error: drop
+parse_with_preset:
+  type: severity_detection_parser
+  preset: detection
+custom_mapping:
+  type: severity_detection_parser
+  mapping:
+    error:
+      - "exception"
+      - "failed"
+    warn:
+      - "warning:"
+      - "attention"
+    info: 
+      - "success"
+      - "completed"
+overwrite_text:
+  type: severity_detection_parser
+  overwrite_text: true
+  mapping:
+    error: "error occurred"


### PR DESCRIPTION
Adding a `severity_detection_parser` to set log severity based on keywords in the log body.

Below is the sample configuration

```- type: severity_detection_parser
      id: severity_detection_parser
      preset: detection  
      mapping:
        error: 
          - error 
          - failed
        warn: warning
        fatal: fatal```