### PR TITLE
receiver/postgresql: add pg connection count metric with attr state application_name user.…

### DIFF
--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -1127,7 +1127,7 @@ func (c *postgreSQLClient) getRowStats(ctx context.Context) ([]RowStats, error) 
 }
 
 type queryStats struct {
-	queryId       string
+	queryID       string
 	queryText     string
 	queryCount    int64
 	queryExecTime int64
@@ -1160,16 +1160,16 @@ func (c *postgreSQLClient) getQueryStats(ctx context.Context) ([]queryStats, err
 	var qs []queryStats
 	var errors error
 	for rows.Next() {
-		var queryId, queryText string
+		var queryID, queryText string
 		var queryCount int64
 		var queryExecTime float64
-		err = rows.Scan(&queryId, &queryText, &queryCount, &queryExecTime)
+		err = rows.Scan(&queryID, &queryText, &queryCount, &queryExecTime)
 		if err != nil {
 			errors = multierr.Append(errors, err)
 		}
 		queryExectimeNS := int64(queryExecTime * 1000000)
 		qs = append(qs, queryStats{
-			queryId:       queryId,
+			queryID:       queryID,
 			queryText:     queryText,
 			queryCount:    queryCount,
 			queryExecTime: queryExectimeNS,

--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -146,6 +146,14 @@ The number of active connections to this database. If DBM is enabled, this metri
 | ---- | ----------- | ---------- | --------- |
 | {connection} | Gauge | Int | Development |
 
+#### Attributes
+
+| Name | Description | Values | Requirement Level |
+| ---- | ----------- | ------ | -------- |
+| postgresql.state | Current overall state of this backend | Any Str | Recommended |
+| postgresql.application_name | Name of the application that is connected to this backend. | Any Str | Recommended |
+| user.name | Name of the user logged into this backend. | Any Str | Recommended |
+
 ### postgresql.connection.max
 
 Configured maximum number of client connections allowed

--- a/receiver/postgresqlreceiver/generated_package_test.go
+++ b/receiver/postgresqlreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package postgresqlreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/postgresqlreceiver/internal/metadata/generated_logs.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_logs.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"context"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/receiver/postgresqlreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_logs_test.go
@@ -4,6 +4,9 @@ package metadata
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -11,8 +14,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"testing"
-	"time"
 )
 
 type eventsTestDataSet int

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
@@ -1350,9 +1350,10 @@ func (m *metricPostgresqlConnectionCount) init() {
 	m.data.SetDescription("The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user")
 	m.data.SetUnit("{connection}")
 	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricPostgresqlConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+func (m *metricPostgresqlConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, postgresqlStateAttributeValue string, postgresqlApplicationNameAttributeValue string, userNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -1360,6 +1361,9 @@ func (m *metricPostgresqlConnectionCount) recordDataPoint(start pcommon.Timestam
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
+	dp.Attributes().PutStr("postgresql.state", postgresqlStateAttributeValue)
+	dp.Attributes().PutStr("postgresql.application_name", postgresqlApplicationNameAttributeValue)
+	dp.Attributes().PutStr("user.name", userNameAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4067,8 +4071,8 @@ func (mb *MetricsBuilder) RecordPostgresqlCommitsDataPoint(ts pcommon.Timestamp,
 }
 
 // RecordPostgresqlConnectionCountDataPoint adds a data point to postgresql.connection.count metric.
-func (mb *MetricsBuilder) RecordPostgresqlConnectionCountDataPoint(ts pcommon.Timestamp, val int64) {
-	mb.metricPostgresqlConnectionCount.recordDataPoint(mb.startTime, ts, val)
+func (mb *MetricsBuilder) RecordPostgresqlConnectionCountDataPoint(ts pcommon.Timestamp, val int64, postgresqlStateAttributeValue string, postgresqlApplicationNameAttributeValue string, userNameAttributeValue string) {
+	mb.metricPostgresqlConnectionCount.recordDataPoint(mb.startTime, ts, val, postgresqlStateAttributeValue, postgresqlApplicationNameAttributeValue, userNameAttributeValue)
 }
 
 // RecordPostgresqlConnectionMaxDataPoint adds a data point to postgresql.connection.max metric.

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
@@ -130,7 +130,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordPostgresqlConnectionCountDataPoint(ts, 1)
+			mb.RecordPostgresqlConnectionCountDataPoint(ts, 1, "postgresql.state-val", "postgresql.application_name-val", "user.name-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -574,6 +574,15 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+					attrVal, ok := dp.Attributes().Get("postgresql.state")
+					assert.True(t, ok)
+					assert.Equal(t, "postgresql.state-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("postgresql.application_name")
+					assert.True(t, ok)
+					assert.Equal(t, "postgresql.application_name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("user.name")
+					assert.True(t, ok)
+					assert.Equal(t, "user.name-val", attrVal.Str())
 				case "postgresql.connection.max":
 					assert.False(t, validatedMetrics["postgresql.connection.max"], "Found a duplicate in the metrics slice: postgresql.connection.max")
 					validatedMetrics["postgresql.connection.max"] = true

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -417,6 +417,7 @@ metrics:
       level: development
     gauge:
       value_type: int
+    attributes: [postgresql.state, postgresql.application_name, user.name]
   postgresql.connection.max:
     enabled: true
     description: Configured maximum number of client connections allowed

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -463,7 +463,8 @@ func (p *postgreSQLScraper) collectTables(ctx context.Context, now pcommon.Times
 		errs.addPartial(err)
 	}
 
-	for tableKey, tm := range tableMetrics {
+	for tableKey := range tableMetrics {
+		tm := tableMetrics[tableKey]
 		p.mb.RecordPostgresqlRowsDataPoint(now, tm.dead, metadata.AttributeStateDead)
 		p.mb.RecordPostgresqlRowsDataPoint(now, tm.live, metadata.AttributeStateLive)
 		p.mb.RecordPostgresqlOperationsDataPoint(now, tm.inserts, metadata.AttributeOperationIns)
@@ -826,8 +827,8 @@ func (p *postgreSQLScraper) collectQueryPerfStats(
 	}
 
 	for _, s := range queryStats {
-		p.mb.RecordPostgresqlQueryCountDataPoint(now, s.queryCount, s.queryText, s.queryId)
-		p.mb.RecordPostgresqlQueryTotalExecTimeDataPoint(now, int64(s.queryExecTime), s.queryText, s.queryId)
+		p.mb.RecordPostgresqlQueryCountDataPoint(now, s.queryCount, s.queryText, s.queryID)
+		p.mb.RecordPostgresqlQueryTotalExecTimeDataPoint(now, s.queryExecTime, s.queryText, s.queryID)
 	}
 }
 

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -982,19 +982,19 @@ func (m *mockClient) initMocks(database, schema string, databases []string, inde
 		}, nil)
 		m.On("getQueryStats", mock.Anything).Return([]queryStats{
 			{
-				queryId:       "6366587321661213570",
+				queryID:       "6366587321661213570",
 				queryText:     "SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department",
 				queryCount:    1,
 				queryExecTime: 16401,
 			},
 			{
-				queryId:       "7034792503091443675",
+				queryID:       "7034792503091443675",
 				queryText:     "SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname",
 				queryCount:    5,
 				queryExecTime: 416529,
 			},
 			{
-				queryId:       "-5872536860935463852",
+				queryID:       "-5872536860935463852",
 				queryText:     "SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)",
 				queryCount:    1,
 				queryExecTime: 25141,

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -73,7 +73,7 @@ func TestScraper(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedFile := filepath.Join("testdata", "scraper", "otel", file)
-			expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceAttributeValue("service.instance.id"), pmetrictest.IgnoreResourceMetricsOrder(),
@@ -126,7 +126,7 @@ func TestScraperNoDatabaseSingle(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedFile := filepath.Join("testdata", "scraper", "otel", file)
-			expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceAttributeValue("service.instance.id"), pmetrictest.IgnoreResourceMetricsOrder(),
@@ -204,7 +204,7 @@ func TestScraperNoDatabaseMultipleWithoutPreciseLag(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedFile := filepath.Join("testdata", "scraper", "multiple", file)
-			expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceAttributeValue("service.instance.id"), pmetrictest.IgnoreResourceMetricsOrder(),
@@ -257,7 +257,7 @@ func TestScraperNoDatabaseMultiple(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedFile := filepath.Join("testdata", "scraper", "multiple", file)
-			expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 		fmt.Println(actualMetrics.ResourceMetrics())
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceAttributeValue("service.instance.id"), pmetrictest.IgnoreResourceMetricsOrder(),
@@ -311,7 +311,7 @@ func TestScraperWithResourceAttributeFeatureGate(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedFile := filepath.Join("testdata", "scraper", "multiple", file)
-			expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceAttributeValue("service.instance.id"), pmetrictest.IgnoreResourceMetricsOrder(),
@@ -364,7 +364,7 @@ func TestScraperWithResourceAttributeFeatureGateSingle(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedFile := filepath.Join("testdata", "scraper", "otel", file)
-			expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceAttributeValue("service.instance.id"), pmetrictest.IgnoreResourceMetricsOrder(),
@@ -391,7 +391,7 @@ func TestScraperExcludeDatabase(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedFile := filepath.Join("testdata", "scraper", "multiple", file)
-			expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceAttributeValue("service.instance.id"), pmetrictest.IgnoreResourceMetricsOrder(),
@@ -720,6 +720,14 @@ func (*mockClient) getWALStats(context.Context) (int64, int64, error) {
 
 func (*mockClient) getTransactionsStats(context.Context) (float64, float64, error) {
 	return 100.0, 500.0, nil
+}
+
+func (*mockClient) getConnectionStats(context.Context, []string) (map[databaseName][]connectionStat, error) {
+	return map[databaseName][]connectionStat{
+		"otel": {
+			{database: "otel", user: "otel", app: "otel", state: "active", count: 1},
+		},
+	}, nil
 }
 
 // close implements postgreSQLClientFactory.

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude.yaml
@@ -6,6 +6,276 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
+          - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
+            gauge:
+              dataPoints:
+                - asInt: "2148"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9053"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: postgres
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: template0
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8527"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: template1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.buffer_hit
+            unit: '{hit}/s'
+          - description: The approximate number of live rows, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "77"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.live_rows
+            unit: '{row}'
+          - description: Number of times the statement was executed.
+            name: postgresql.query.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "-5872536860935463852"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "6366587321661213570"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "7034792503091443675"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: Total wait time of the normalised timed events in nanaoseconds.
+            name: postgresql.query.total_exec_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "25141"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "-5872536860935463852"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16401"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "6366587321661213570"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "416529"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "7034792503091443675"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: ns
+          - description: Rows deleted by queries in this db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "88"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_deleted
+            unit: '{row}/s'
+          - description: Rows fetched by queries in this db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_fetched
+            unit: '{row}/s'
+          - description: Rows inserted by queries in the db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "165"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_inserted
+            unit: '{row}/s'
+          - description: Rows updated by queries in the db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_updated
+            unit: '{row}/s'
+          - description: Max duration of active transactions.
+            gauge:
+              dataPoints:
+                - asDouble: 100
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.transactions.duration.max
+            unit: ms
+          - description: Sum of duration of active transactions.
+            gauge:
+              dataPoints:
+                - asDouble: 500
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.transactions.duration.sum
+            unit: ms
+          - description: Number of WAL files.
+            gauge:
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.count
+            unit: "1"
+          - description: Total size of WAL files.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.size
+            unit: By
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{table}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
           - description: Number of buffers allocated.
             name: postgresql.bgwriter.buffers.allocated
             sum:
@@ -103,39 +373,24 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
-          - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
             gauge:
               dataPoints:
-                - asInt: "2148"
+                - asInt: "1"
                   attributes:
-                    - key: dbname
+                    - key: postgresql.application_name
                       value:
-                        stringValue: ""
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "9053"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: postgres
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: template0
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8527"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: template1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.buffer_hit
-            unit: '{hit}/s'
+            name: postgresql.connection.count
+            unit: '{connection}'
           - description: Configured maximum number of client connections allowed
             gauge:
               dataPoints:
@@ -153,90 +408,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{databases}'
-          - description: The approximate number of live rows, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "77"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.live_rows
-            unit: '{row}'
-          - description: Number of times the statement was executed.
-            name: postgresql.query.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "-5872536860935463852"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "6366587321661213570"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "7034792503091443675"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Total wait time of the normalised timed events in nanaoseconds.
-            name: postgresql.query.total_exec_time
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "25141"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "-5872536860935463852"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "16401"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "6366587321661213570"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "416529"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "7034792503091443675"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: ns
           - description: The amount of data delayed in replication.
             gauge:
               dataPoints:
@@ -249,70 +420,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.replication.data_delay
             unit: By
-          - description: Rows deleted by queries in this db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "88"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_deleted
-            unit: '{row}/s'
-          - description: Rows fetched by queries in this db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_fetched
-            unit: '{row}/s'
-          - description: Rows inserted by queries in the db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "165"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_inserted
-            unit: '{row}/s'
-          - description: Rows updated by queries in the db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "2"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_updated
-            unit: '{row}/s'
-          - description: Max duration of active transactions.
-            gauge:
-              dataPoints:
-                - asDouble: 100
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.transactions.duration.max
-            unit: ms
-          - description: Sum of duration of active transactions.
-            gauge:
-              dataPoints:
-                - asDouble: 500
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.transactions.duration.sum
-            unit: ms
           - description: Age of the oldest WAL file.
             gauge:
               dataPoints:
@@ -321,82 +428,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.age
             unit: s
-          - description: Number of WAL files.
-            gauge:
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.count
-            unit: "1"
-          - description: Total size of WAL files.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.size
-            unit: By
-        scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: otel
-        - key: service.instance.id
-          value:
-            stringValue: arjun-Latitude-3540:5432
-    scopeMetrics:
-      - metrics:
-          - description: The number of backends.
-            name: postgresql.backends
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: The number of commits.
-            name: postgresql.commits
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The database disk usage.
-            name: postgresql.db_size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "4"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: The number of rollbacks.
-            name: postgresql.rollbacks
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: Number of user tables in a database.
-            name: postgresql.table.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{table}'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude_schemaattr.yaml
@@ -6,6 +6,276 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
+          - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
+            gauge:
+              dataPoints:
+                - asInt: "2148"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9053"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: postgres
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: template0
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8527"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: template1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.buffer_hit
+            unit: '{hit}/s'
+          - description: The approximate number of live rows, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "77"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.live_rows
+            unit: '{row}'
+          - description: Number of times the statement was executed.
+            name: postgresql.query.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "-5872536860935463852"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "6366587321661213570"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "7034792503091443675"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: Total wait time of the normalised timed events in nanaoseconds.
+            name: postgresql.query.total_exec_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "25141"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "-5872536860935463852"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16401"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "6366587321661213570"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "416529"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "7034792503091443675"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: ns
+          - description: Rows deleted by queries in this db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "88"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_deleted
+            unit: '{row}/s'
+          - description: Rows fetched by queries in this db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_fetched
+            unit: '{row}/s'
+          - description: Rows inserted by queries in the db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "165"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_inserted
+            unit: '{row}/s'
+          - description: Rows updated by queries in the db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_updated
+            unit: '{row}/s'
+          - description: Max duration of active transactions.
+            gauge:
+              dataPoints:
+                - asDouble: 100
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.transactions.duration.max
+            unit: ms
+          - description: Sum of duration of active transactions.
+            gauge:
+              dataPoints:
+                - asDouble: 500
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.transactions.duration.sum
+            unit: ms
+          - description: Number of WAL files.
+            gauge:
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.count
+            unit: "1"
+          - description: Total size of WAL files.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.size
+            unit: By
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{table}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
           - description: Number of buffers allocated.
             name: postgresql.bgwriter.buffers.allocated
             sum:
@@ -103,39 +373,24 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
-          - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
             gauge:
               dataPoints:
-                - asInt: "2148"
+                - asInt: "1"
                   attributes:
-                    - key: dbname
+                    - key: postgresql.application_name
                       value:
-                        stringValue: ""
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "9053"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: postgres
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: template0
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8527"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: template1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.buffer_hit
-            unit: '{hit}/s'
+            name: postgresql.connection.count
+            unit: '{connection}'
           - description: Configured maximum number of client connections allowed
             gauge:
               dataPoints:
@@ -153,90 +408,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{databases}'
-          - description: The approximate number of live rows, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "77"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.live_rows
-            unit: '{row}'
-          - description: Number of times the statement was executed.
-            name: postgresql.query.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "-5872536860935463852"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "6366587321661213570"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "7034792503091443675"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Total wait time of the normalised timed events in nanaoseconds.
-            name: postgresql.query.total_exec_time
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "25141"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "-5872536860935463852"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "16401"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "6366587321661213570"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "416529"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "7034792503091443675"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: ns
           - description: The amount of data delayed in replication.
             gauge:
               dataPoints:
@@ -249,70 +420,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.replication.data_delay
             unit: By
-          - description: Rows deleted by queries in this db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "88"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_deleted
-            unit: '{row}/s'
-          - description: Rows fetched by queries in this db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_fetched
-            unit: '{row}/s'
-          - description: Rows inserted by queries in the db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "165"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_inserted
-            unit: '{row}/s'
-          - description: Rows updated by queries in the db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "2"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_updated
-            unit: '{row}/s'
-          - description: Max duration of active transactions.
-            gauge:
-              dataPoints:
-                - asDouble: 100
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.transactions.duration.max
-            unit: ms
-          - description: Sum of duration of active transactions.
-            gauge:
-              dataPoints:
-                - asDouble: 500
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.transactions.duration.sum
-            unit: ms
           - description: Age of the oldest WAL file.
             gauge:
               dataPoints:
@@ -321,82 +428,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.age
             unit: s
-          - description: Number of WAL files.
-            gauge:
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.count
-            unit: "1"
-          - description: Total size of WAL files.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.size
-            unit: By
-        scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: otel
-        - key: service.instance.id
-          value:
-            stringValue: arjun-Latitude-3540:5432
-    scopeMetrics:
-      - metrics:
-          - description: The number of backends.
-            name: postgresql.backends
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: The number of commits.
-            name: postgresql.commits
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The database disk usage.
-            name: postgresql.db_size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "4"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: The number of rollbacks.
-            name: postgresql.rollbacks
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: Number of user tables in a database.
-            name: postgresql.table.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{table}'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
@@ -6,103 +6,6 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
-          - description: Number of buffers allocated.
-            name: postgresql.bgwriter.buffers.allocated
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: Number of buffers written.
-            name: postgresql.bgwriter.buffers.writes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "7"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend_fsync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: The number of checkpoints performed.
-            name: postgresql.bgwriter.checkpoint.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: requested
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "2"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: scheduled
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{checkpoints}'
-          - description: Total time spent writing and syncing files to disk by checkpoints.
-            name: postgresql.bgwriter.duration
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 4.23
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3.12
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: ms
-          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
-            name: postgresql.bgwriter.maxwritten
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "11"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
           - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
             gauge:
               dataPoints:
@@ -136,23 +39,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.buffer_hit
             unit: '{hit}/s'
-          - description: Configured maximum number of client connections allowed
-            gauge:
-              dataPoints:
-                - asInt: "100"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.connection.max
-            unit: '{connection}'
-          - description: Number of user databases.
-            name: postgresql.database.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{databases}'
           - description: The number of database locks.
             gauge:
               dataPoints:
@@ -268,18 +154,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: ns
-          - description: The amount of data delayed in replication.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  attributes:
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.replication.data_delay
-            unit: By
           - description: Rows deleted by queries in this db, tagged with relation name.
             gauge:
               dataPoints:
@@ -344,14 +218,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.transactions.duration.sum
             unit: ms
-          - description: Age of the oldest WAL file.
-            gauge:
-              dataPoints:
-                - asInt: "3600"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.age
-            unit: s
           - description: Number of WAL files.
             gauge:
               dataPoints:
@@ -360,41 +226,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.count
             unit: "1"
-          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
-            gauge:
-              dataPoints:
-                - asDouble: 600.4
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 700.55
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: replay
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 800.66
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: write
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.delay
-            unit: s
           - description: Total size of WAL files.
             gauge:
               dataPoints:
@@ -723,6 +554,206 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{tup_updated}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 4.23
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 3.12
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "11"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: postgresql.application_name
+                      value:
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.count
+            unit: '{connection}'
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.max
+            unit: '{connection}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{databases}'
+          - description: The amount of data delayed in replication.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  attributes:
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.replication.data_delay
+            unit: By
+          - description: Age of the oldest WAL file.
+            gauge:
+              dataPoints:
+                - asInt: "3600"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.age
+            unit: s
+          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
+            gauge:
+              dataPoints:
+                - asDouble: 600.4
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 700.55
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: replay
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 800.66
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: write
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.delay
+            unit: s
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag.yaml
@@ -6,103 +6,6 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
-          - description: Number of buffers allocated.
-            name: postgresql.bgwriter.buffers.allocated
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: Number of buffers written.
-            name: postgresql.bgwriter.buffers.writes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "7"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend_fsync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: The number of checkpoints performed.
-            name: postgresql.bgwriter.checkpoint.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: requested
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "2"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: scheduled
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{checkpoints}'
-          - description: Total time spent writing and syncing files to disk by checkpoints.
-            name: postgresql.bgwriter.duration
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 4.23
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3.12
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: ms
-          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
-            name: postgresql.bgwriter.maxwritten
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "11"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
           - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
             gauge:
               dataPoints:
@@ -136,23 +39,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.buffer_hit
             unit: '{hit}/s'
-          - description: Configured maximum number of client connections allowed
-            gauge:
-              dataPoints:
-                - asInt: "100"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.connection.max
-            unit: '{connection}'
-          - description: Number of user databases.
-            name: postgresql.database.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{databases}'
           - description: The number of database locks.
             gauge:
               dataPoints:
@@ -268,18 +154,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: ns
-          - description: The amount of data delayed in replication.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  attributes:
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.replication.data_delay
-            unit: By
           - description: Rows deleted by queries in this db, tagged with relation name.
             gauge:
               dataPoints:
@@ -344,14 +218,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.transactions.duration.sum
             unit: ms
-          - description: Age of the oldest WAL file.
-            gauge:
-              dataPoints:
-                - asInt: "3600"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.age
-            unit: s
           - description: Number of WAL files.
             gauge:
               dataPoints:
@@ -360,41 +226,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.count
             unit: "1"
-          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
-            gauge:
-              dataPoints:
-                - asInt: "600"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "700"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: replay
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "800"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: write
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.lag
-            unit: s
           - description: Total size of WAL files.
             gauge:
               dataPoints:
@@ -723,6 +554,206 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{tup_updated}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 4.23
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 3.12
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "11"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: postgresql.application_name
+                      value:
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.count
+            unit: '{connection}'
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.max
+            unit: '{connection}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{databases}'
+          - description: The amount of data delayed in replication.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  attributes:
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.replication.data_delay
+            unit: By
+          - description: Age of the oldest WAL file.
+            gauge:
+              dataPoints:
+                - asInt: "3600"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.age
+            unit: s
+          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
+            gauge:
+              dataPoints:
+                - asInt: "600"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "700"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: replay
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "800"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: write
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.lag
+            unit: s
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag_schemaattr.yaml
@@ -6,103 +6,6 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
-          - description: Number of buffers allocated.
-            name: postgresql.bgwriter.buffers.allocated
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: Number of buffers written.
-            name: postgresql.bgwriter.buffers.writes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "7"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend_fsync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: The number of checkpoints performed.
-            name: postgresql.bgwriter.checkpoint.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: requested
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "2"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: scheduled
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{checkpoints}'
-          - description: Total time spent writing and syncing files to disk by checkpoints.
-            name: postgresql.bgwriter.duration
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 4.23
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3.12
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: ms
-          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
-            name: postgresql.bgwriter.maxwritten
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "11"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
           - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
             gauge:
               dataPoints:
@@ -136,23 +39,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.buffer_hit
             unit: '{hit}/s'
-          - description: Configured maximum number of client connections allowed
-            gauge:
-              dataPoints:
-                - asInt: "100"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.connection.max
-            unit: '{connection}'
-          - description: Number of user databases.
-            name: postgresql.database.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{databases}'
           - description: The number of database locks.
             gauge:
               dataPoints:
@@ -268,18 +154,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: ns
-          - description: The amount of data delayed in replication.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  attributes:
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.replication.data_delay
-            unit: By
           - description: Rows deleted by queries in this db, tagged with relation name.
             gauge:
               dataPoints:
@@ -344,14 +218,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.transactions.duration.sum
             unit: ms
-          - description: Age of the oldest WAL file.
-            gauge:
-              dataPoints:
-                - asInt: "3600"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.age
-            unit: s
           - description: Number of WAL files.
             gauge:
               dataPoints:
@@ -360,41 +226,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.count
             unit: "1"
-          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
-            gauge:
-              dataPoints:
-                - asInt: "600"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "700"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: replay
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "800"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: write
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.lag
-            unit: s
           - description: Total size of WAL files.
             gauge:
               dataPoints:
@@ -723,6 +554,206 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{tup_updated}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 4.23
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 3.12
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "11"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: postgresql.application_name
+                      value:
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.count
+            unit: '{connection}'
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.max
+            unit: '{connection}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{databases}'
+          - description: The amount of data delayed in replication.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  attributes:
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.replication.data_delay
+            unit: By
+          - description: Age of the oldest WAL file.
+            gauge:
+              dataPoints:
+                - asInt: "3600"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.age
+            unit: s
+          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
+            gauge:
+              dataPoints:
+                - asInt: "600"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "700"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: replay
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "800"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: write
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.lag
+            unit: s
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
@@ -6,103 +6,6 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
-          - description: Number of buffers allocated.
-            name: postgresql.bgwriter.buffers.allocated
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: Number of buffers written.
-            name: postgresql.bgwriter.buffers.writes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "7"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend_fsync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: The number of checkpoints performed.
-            name: postgresql.bgwriter.checkpoint.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: requested
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "2"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: scheduled
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{checkpoints}'
-          - description: Total time spent writing and syncing files to disk by checkpoints.
-            name: postgresql.bgwriter.duration
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 4.23
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3.12
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: ms
-          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
-            name: postgresql.bgwriter.maxwritten
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "11"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
           - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
             gauge:
               dataPoints:
@@ -136,23 +39,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.buffer_hit
             unit: '{hit}/s'
-          - description: Configured maximum number of client connections allowed
-            gauge:
-              dataPoints:
-                - asInt: "100"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.connection.max
-            unit: '{connection}'
-          - description: Number of user databases.
-            name: postgresql.database.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{databases}'
           - description: The number of database locks.
             gauge:
               dataPoints:
@@ -268,18 +154,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: ns
-          - description: The amount of data delayed in replication.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  attributes:
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.replication.data_delay
-            unit: By
           - description: Rows deleted by queries in this db, tagged with relation name.
             gauge:
               dataPoints:
@@ -344,14 +218,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.transactions.duration.sum
             unit: ms
-          - description: Age of the oldest WAL file.
-            gauge:
-              dataPoints:
-                - asInt: "3600"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.age
-            unit: s
           - description: Number of WAL files.
             gauge:
               dataPoints:
@@ -360,41 +226,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.count
             unit: "1"
-          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
-            gauge:
-              dataPoints:
-                - asDouble: 600.4
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 700.55
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: replay
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 800.66
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: write
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.delay
-            unit: s
           - description: Total size of WAL files.
             gauge:
               dataPoints:
@@ -723,6 +554,206 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{tup_updated}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 4.23
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 3.12
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "11"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: postgresql.application_name
+                      value:
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.count
+            unit: '{connection}'
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.max
+            unit: '{connection}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{databases}'
+          - description: The amount of data delayed in replication.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  attributes:
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.replication.data_delay
+            unit: By
+          - description: Age of the oldest WAL file.
+            gauge:
+              dataPoints:
+                - asInt: "3600"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.age
+            unit: s
+          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
+            gauge:
+              dataPoints:
+                - asDouble: 600.4
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 700.55
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: replay
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 800.66
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: write
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.delay
+            unit: s
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
@@ -6,103 +6,6 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
-          - description: Number of buffers allocated.
-            name: postgresql.bgwriter.buffers.allocated
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: Number of buffers written.
-            name: postgresql.bgwriter.buffers.writes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "7"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend_fsync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: The number of checkpoints performed.
-            name: postgresql.bgwriter.checkpoint.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: requested
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "2"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: scheduled
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{checkpoints}'
-          - description: Total time spent writing and syncing files to disk by checkpoints.
-            name: postgresql.bgwriter.duration
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 4.23
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3.12
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: ms
-          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
-            name: postgresql.bgwriter.maxwritten
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "11"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
           - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
             gauge:
               dataPoints:
@@ -136,23 +39,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.buffer_hit
             unit: '{hit}/s'
-          - description: Configured maximum number of client connections allowed
-            gauge:
-              dataPoints:
-                - asInt: "100"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.connection.max
-            unit: '{connection}'
-          - description: Number of user databases.
-            name: postgresql.database.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{databases}'
           - description: The number of database locks.
             gauge:
               dataPoints:
@@ -268,18 +154,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: ns
-          - description: The amount of data delayed in replication.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  attributes:
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.replication.data_delay
-            unit: By
           - description: Rows deleted by queries in this db, tagged with relation name.
             gauge:
               dataPoints:
@@ -344,14 +218,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.transactions.duration.sum
             unit: ms
-          - description: Age of the oldest WAL file.
-            gauge:
-              dataPoints:
-                - asInt: "3600"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.age
-            unit: s
           - description: Number of WAL files.
             gauge:
               dataPoints:
@@ -360,41 +226,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.count
             unit: "1"
-          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
-            gauge:
-              dataPoints:
-                - asDouble: 600.4
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 700.55
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: replay
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 800.66
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: write
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.delay
-            unit: s
           - description: Total size of WAL files.
             gauge:
               dataPoints:
@@ -563,6 +394,206 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{tup_updated}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 4.23
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 3.12
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "11"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: postgresql.application_name
+                      value:
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.count
+            unit: '{connection}'
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.max
+            unit: '{connection}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{databases}'
+          - description: The amount of data delayed in replication.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  attributes:
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.replication.data_delay
+            unit: By
+          - description: Age of the oldest WAL file.
+            gauge:
+              dataPoints:
+                - asInt: "3600"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.age
+            unit: s
+          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
+            gauge:
+              dataPoints:
+                - asDouble: 600.4
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 700.55
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: replay
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 800.66
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: write
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.delay
+            unit: s
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics.yaml
@@ -6,6 +6,276 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
+          - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
+            gauge:
+              dataPoints:
+                - asInt: "2148"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9053"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: postgres
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: template0
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8527"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: template1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.buffer_hit
+            unit: '{hit}/s'
+          - description: The approximate number of live rows, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "77"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.live_rows
+            unit: '{row}'
+          - description: Number of times the statement was executed.
+            name: postgresql.query.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "-5872536860935463852"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "6366587321661213570"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "7034792503091443675"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: Total wait time of the normalised timed events in nanaoseconds.
+            name: postgresql.query.total_exec_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "25141"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "-5872536860935463852"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16401"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "6366587321661213570"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "416529"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "7034792503091443675"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: ns
+          - description: Rows deleted by queries in this db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "88"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_deleted
+            unit: '{row}/s'
+          - description: Rows fetched by queries in this db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_fetched
+            unit: '{row}/s'
+          - description: Rows inserted by queries in the db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "165"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_inserted
+            unit: '{row}/s'
+          - description: Rows updated by queries in the db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_updated
+            unit: '{row}/s'
+          - description: Max duration of active transactions.
+            gauge:
+              dataPoints:
+                - asDouble: 100
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.transactions.duration.max
+            unit: ms
+          - description: Sum of duration of active transactions.
+            gauge:
+              dataPoints:
+                - asDouble: 500
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.transactions.duration.sum
+            unit: ms
+          - description: Number of WAL files.
+            gauge:
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.count
+            unit: "1"
+          - description: Total size of WAL files.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.size
+            unit: By
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{table}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
           - description: Number of buffers allocated.
             name: postgresql.bgwriter.buffers.allocated
             sum:
@@ -103,39 +373,24 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
-          - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
             gauge:
               dataPoints:
-                - asInt: "2148"
+                - asInt: "1"
                   attributes:
-                    - key: dbname
+                    - key: postgresql.application_name
                       value:
-                        stringValue: ""
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "9053"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: postgres
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: template0
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8527"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: template1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.buffer_hit
-            unit: '{hit}/s'
+            name: postgresql.connection.count
+            unit: '{connection}'
           - description: Configured maximum number of client connections allowed
             gauge:
               dataPoints:
@@ -153,90 +408,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{databases}'
-          - description: The approximate number of live rows, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "77"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.live_rows
-            unit: '{row}'
-          - description: Number of times the statement was executed.
-            name: postgresql.query.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "-5872536860935463852"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "6366587321661213570"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "7034792503091443675"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Total wait time of the normalised timed events in nanaoseconds.
-            name: postgresql.query.total_exec_time
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "25141"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "-5872536860935463852"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "16401"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "6366587321661213570"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "416529"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "7034792503091443675"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: ns
           - description: The amount of data delayed in replication.
             gauge:
               dataPoints:
@@ -249,70 +420,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.replication.data_delay
             unit: By
-          - description: Rows deleted by queries in this db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "88"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_deleted
-            unit: '{row}/s'
-          - description: Rows fetched by queries in this db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_fetched
-            unit: '{row}/s'
-          - description: Rows inserted by queries in the db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "165"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_inserted
-            unit: '{row}/s'
-          - description: Rows updated by queries in the db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "2"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_updated
-            unit: '{row}/s'
-          - description: Max duration of active transactions.
-            gauge:
-              dataPoints:
-                - asDouble: 100
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.transactions.duration.max
-            unit: ms
-          - description: Sum of duration of active transactions.
-            gauge:
-              dataPoints:
-                - asDouble: 500
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.transactions.duration.sum
-            unit: ms
           - description: Age of the oldest WAL file.
             gauge:
               dataPoints:
@@ -321,82 +428,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.age
             unit: s
-          - description: Number of WAL files.
-            gauge:
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.count
-            unit: "1"
-          - description: Total size of WAL files.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.size
-            unit: By
-        scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: otel
-        - key: service.instance.id
-          value:
-            stringValue: arjun-Latitude-3540:5432
-    scopeMetrics:
-      - metrics:
-          - description: The number of backends.
-            name: postgresql.backends
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: The number of commits.
-            name: postgresql.commits
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The database disk usage.
-            name: postgresql.db_size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "4"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: The number of rollbacks.
-            name: postgresql.rollbacks
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: Number of user tables in a database.
-            name: postgresql.table.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{table}'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics_schemaattr.yaml
@@ -6,6 +6,276 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
+          - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
+            gauge:
+              dataPoints:
+                - asInt: "2148"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9053"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: postgres
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: template0
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8527"
+                  attributes:
+                    - key: dbname
+                      value:
+                        stringValue: template1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.buffer_hit
+            unit: '{hit}/s'
+          - description: The approximate number of live rows, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "77"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.live_rows
+            unit: '{row}'
+          - description: Number of times the statement was executed.
+            name: postgresql.query.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "-5872536860935463852"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "6366587321661213570"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "7034792503091443675"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: Total wait time of the normalised timed events in nanaoseconds.
+            name: postgresql.query.total_exec_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "25141"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "-5872536860935463852"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16401"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "6366587321661213570"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "416529"
+                  attributes:
+                    - key: query_id
+                      value:
+                        stringValue: "7034792503091443675"
+                    - key: query_text
+                      value:
+                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: ns
+          - description: Rows deleted by queries in this db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "88"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_deleted
+            unit: '{row}/s'
+          - description: Rows fetched by queries in this db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_fetched
+            unit: '{row}/s'
+          - description: Rows inserted by queries in the db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "165"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_inserted
+            unit: '{row}/s'
+          - description: Rows updated by queries in the db, tagged with relation name.
+            gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: relation_name
+                      value:
+                        stringValue: public.table1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.rows_updated
+            unit: '{row}/s'
+          - description: Max duration of active transactions.
+            gauge:
+              dataPoints:
+                - asDouble: 100
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.transactions.duration.max
+            unit: ms
+          - description: Sum of duration of active transactions.
+            gauge:
+              dataPoints:
+                - asDouble: 500
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.transactions.duration.sum
+            unit: ms
+          - description: Number of WAL files.
+            gauge:
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.count
+            unit: "1"
+          - description: Total size of WAL files.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.size
+            unit: By
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{table}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
           - description: Number of buffers allocated.
             name: postgresql.bgwriter.buffers.allocated
             sum:
@@ -103,39 +373,24 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
-          - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
             gauge:
               dataPoints:
-                - asInt: "2148"
+                - asInt: "1"
                   attributes:
-                    - key: dbname
+                    - key: postgresql.application_name
                       value:
-                        stringValue: ""
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "9053"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: postgres
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: template0
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8527"
-                  attributes:
-                    - key: dbname
-                      value:
-                        stringValue: template1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.buffer_hit
-            unit: '{hit}/s'
+            name: postgresql.connection.count
+            unit: '{connection}'
           - description: Configured maximum number of client connections allowed
             gauge:
               dataPoints:
@@ -153,90 +408,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{databases}'
-          - description: The approximate number of live rows, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "77"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.live_rows
-            unit: '{row}'
-          - description: Number of times the statement was executed.
-            name: postgresql.query.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "-5872536860935463852"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "6366587321661213570"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "7034792503091443675"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Total wait time of the normalised timed events in nanaoseconds.
-            name: postgresql.query.total_exec_time
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "25141"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "-5872536860935463852"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT MIN(salary) AS lowest_salary_in_highest_paying_dept FROM employees WHERE department = (SELECT department FROM employees GROUP BY department ORDER BY AVG(salary) DESC LIMIT $1)
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "16401"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "6366587321661213570"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT department, COUNT(*) AS num_employees FROM employees GROUP BY department
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "416529"
-                  attributes:
-                    - key: query_id
-                      value:
-                        stringValue: "7034792503091443675"
-                    - key: query_text
-                      value:
-                        stringValue: SELECT datname, count(*) as count from pg_stat_activity WHERE datname IN ($1) GROUP BY datname
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: ns
           - description: The amount of data delayed in replication.
             gauge:
               dataPoints:
@@ -249,70 +420,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.replication.data_delay
             unit: By
-          - description: Rows deleted by queries in this db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "88"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_deleted
-            unit: '{row}/s'
-          - description: Rows fetched by queries in this db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_fetched
-            unit: '{row}/s'
-          - description: Rows inserted by queries in the db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "165"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_inserted
-            unit: '{row}/s'
-          - description: Rows updated by queries in the db, tagged with relation name.
-            gauge:
-              dataPoints:
-                - asInt: "2"
-                  attributes:
-                    - key: relation_name
-                      value:
-                        stringValue: public.table1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.rows_updated
-            unit: '{row}/s'
-          - description: Max duration of active transactions.
-            gauge:
-              dataPoints:
-                - asDouble: 100
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.transactions.duration.max
-            unit: ms
-          - description: Sum of duration of active transactions.
-            gauge:
-              dataPoints:
-                - asDouble: 500
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.transactions.duration.sum
-            unit: ms
           - description: Age of the oldest WAL file.
             gauge:
               dataPoints:
@@ -321,82 +428,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.age
             unit: s
-          - description: Number of WAL files.
-            gauge:
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.count
-            unit: "1"
-          - description: Total size of WAL files.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.size
-            unit: By
-        scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: otel
-        - key: service.instance.id
-          value:
-            stringValue: arjun-Latitude-3540:5432
-    scopeMetrics:
-      - metrics:
-          - description: The number of backends.
-            name: postgresql.backends
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: The number of commits.
-            name: postgresql.commits
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The database disk usage.
-            name: postgresql.db_size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "4"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: The number of rollbacks.
-            name: postgresql.rollbacks
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: Number of user tables in a database.
-            name: postgresql.table.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{table}'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
@@ -6,103 +6,6 @@ resourceMetrics:
             stringValue: arjun-Latitude-3540:5432
     scopeMetrics:
       - metrics:
-          - description: Number of buffers allocated.
-            name: postgresql.bgwriter.buffers.allocated
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: Number of buffers written.
-            name: postgresql.bgwriter.buffers.writes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "7"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend_fsync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{buffers}'
-          - description: The number of checkpoints performed.
-            name: postgresql.bgwriter.checkpoint.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: requested
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "2"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: scheduled
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{checkpoints}'
-          - description: Total time spent writing and syncing files to disk by checkpoints.
-            name: postgresql.bgwriter.duration
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 4.23
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3.12
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: ms
-          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
-            name: postgresql.bgwriter.maxwritten
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "11"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
           - description: The number of disk block hits in the buffer cache, thereby avoiding database reads, tagged with database name.
             gauge:
               dataPoints:
@@ -136,23 +39,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.buffer_hit
             unit: '{hit}/s'
-          - description: Configured maximum number of client connections allowed
-            gauge:
-              dataPoints:
-                - asInt: "100"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.connection.max
-            unit: '{connection}'
-          - description: Number of user databases.
-            name: postgresql.database.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{databases}'
           - description: The number of database locks.
             gauge:
               dataPoints:
@@ -268,18 +154,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: ns
-          - description: The amount of data delayed in replication.
-            gauge:
-              dataPoints:
-                - asInt: "1024"
-                  attributes:
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.replication.data_delay
-            unit: By
           - description: Rows deleted by queries in this db, tagged with relation name.
             gauge:
               dataPoints:
@@ -344,14 +218,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.transactions.duration.sum
             unit: ms
-          - description: Age of the oldest WAL file.
-            gauge:
-              dataPoints:
-                - asInt: "3600"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.age
-            unit: s
           - description: Number of WAL files.
             gauge:
               dataPoints:
@@ -360,41 +226,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: postgresql.wal.count
             unit: "1"
-          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
-            gauge:
-              dataPoints:
-                - asDouble: 600.4
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 700.55
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: replay
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 800.66
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: write
-                    - key: replication_client
-                      value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.delay
-            unit: s
           - description: Total size of WAL files.
             gauge:
               dataPoints:
@@ -563,6 +394,206 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{tup_updated}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: service.instance.id
+          value:
+            stringValue: arjun-Latitude-3540:5432
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 4.23
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 3.12
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "11"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: postgresql.application_name
+                      value:
+                        stringValue: otel
+                    - key: postgresql.state
+                      value:
+                        stringValue: active
+                    - key: user.name
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.count
+            unit: '{connection}'
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.connection.max
+            unit: '{connection}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{databases}'
+          - description: The amount of data delayed in replication.
+            gauge:
+              dataPoints:
+                - asInt: "1024"
+                  attributes:
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.replication.data_delay
+            unit: By
+          - description: Age of the oldest WAL file.
+            gauge:
+              dataPoints:
+                - asInt: "3600"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.age
+            unit: s
+          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
+            gauge:
+              dataPoints:
+                - asDouble: 600.4
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 700.55
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: replay
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 800.66
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: write
+                    - key: replication_client
+                      value:
+                        stringValue: unix
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.wal.delay
+            unit: s
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest


### PR DESCRIPTION
postgresql.connection.count:
    enabled: true
    description: The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user
    unit: '{connection}'
    stability:
      level: development
    gauge:
      value_type: int
    attributes: [postgresql.state, postgresql.application_name, user.name]