### PR TITLE
AGE-419(Fix-K8sClusterReceiver-Ingress): k8sclusterreceiver is breaking due to blank Ingress Rules

### DIFF
--- a/receiver/k8sclusterreceiver/internal/clusterrolebinding/clusterrolebinding.go
+++ b/receiver/k8sclusterreceiver/internal/clusterrolebinding/clusterrolebinding.go
@@ -66,14 +66,20 @@ func convertSubjectsToString(subjects []rbacv1.Subject) string {
 			result.WriteString(";")
 		}
 
-		result.WriteString("kind=")
-		result.WriteString(subject.Kind)
+		if subject.Kind != "" {
+			result.WriteString("kind=")
+			result.WriteString(subject.Kind)
+		}
 
-		result.WriteString("&name=")
-		result.WriteString(subject.Name)
+		if subject.Name != "" {
+			result.WriteString("&name=")
+			result.WriteString(subject.Name)
+		}
 
-		result.WriteString("&namespace=")
-		result.WriteString(subject.Namespace)
+		if subject.Namespace != "" {
+			result.WriteString("&namespace=")
+			result.WriteString(subject.Namespace)
+		}
 	}
 
 	return result.String()

--- a/receiver/k8sclusterreceiver/internal/ingress/ingress.go
+++ b/receiver/k8sclusterreceiver/internal/ingress/ingress.go
@@ -66,23 +66,32 @@ func convertIngressRulesToString(rules []netv1.IngressRule) string {
 		result.WriteString("host=")
 		result.WriteString(rule.Host)
 
-		result.WriteString("&http=(paths=")
-		for j, path := range rule.HTTP.Paths {
-			if j > 0 {
-				result.WriteString("&")
-			}
+		if rule.HTTP != nil {
+			result.WriteString("&http=(paths=")
+			for j, path := range rule.HTTP.Paths {
+				if j > 0 {
+					result.WriteString("&")
+				}
 
-			result.WriteString("(path=")
-			result.WriteString(path.Path)
-			result.WriteString("&pathType=")
-			result.WriteString(string(*path.PathType))
-			result.WriteString("&backend=(service=(name=")
-			result.WriteString(path.Backend.Service.Name)
-			result.WriteString("&port=(number=")
-			result.WriteString(fmt.Sprintf("%d", path.Backend.Service.Port.Number))
-			result.WriteString(")))")
+				result.WriteString("(path=")
+				result.WriteString(path.Path)
+				result.WriteString("&pathType=")
+				if path.PathType != nil {
+					result.WriteString(string(*path.PathType))
+				}
+				result.WriteString("&backend=(service=(")
+				if path.Backend.Service != nil {
+					result.WriteString("name=")
+					result.WriteString(path.Backend.Service.Name)
+					result.WriteString("&port=(number=")
+					result.WriteString(fmt.Sprintf("%d", path.Backend.Service.Port.Number))
+					result.WriteString(")")
+				}
+				result.WriteString("))")
+				result.WriteString(")")
+			}
+			result.WriteString(")")
 		}
-		result.WriteString(")")
 	}
 
 	return result.String()

--- a/receiver/k8sclusterreceiver/internal/ingress/ingress_test.go
+++ b/receiver/k8sclusterreceiver/internal/ingress/ingress_test.go
@@ -23,3 +23,58 @@ func TestTransform(t *testing.T) {
 	}
 	assert.Equal(t, wantI, Transform(originalI))
 }
+
+func TestConvertIngressRulesToString(t *testing.T) {
+	pathType := netv1.PathTypePrefix
+	tests := []struct {
+		name     string
+		rules    []netv1.IngressRule
+		expected string
+	}{
+		{
+			name: "single rule with path",
+			rules: []netv1.IngressRule{
+				{
+					Host: "hello.local",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &pathType,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "hello",
+											Port: netv1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "host=hello.local&http=(paths=(path=/&pathType=Prefix&backend=(service=(name=hello&port=(number=80)))))",
+		},
+		{
+			name: "rule with nil HTTP",
+			rules: []netv1.IngressRule{
+				{
+					Host: "hello.local",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: nil,
+					},
+				},
+			},
+			expected: "host=hello.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, convertIngressRulesToString(tt.rules))
+		})
+	}
+}

--- a/receiver/k8sclusterreceiver/internal/role/role.go
+++ b/receiver/k8sclusterreceiver/internal/role/role.go
@@ -63,21 +63,35 @@ func convertRulesToString(rules []rbacv1.PolicyRule) string {
 			result.WriteString(";")
 		}
 
-		result.WriteString("verbs=")
-		result.WriteString(strings.Join(rule.Verbs, ","))
+		// verbs
+		if len(rule.Verbs) > 0 {
+			result.WriteString("verbs=")
+			result.WriteString(strings.Join(rule.Verbs, ","))
+		}
 
-		result.WriteString("&apiGroups=")
-		result.WriteString(strings.Join(rule.APIGroups, ","))
+		// apiGroups
+		if len(rule.APIGroups) > 0 {
+			result.WriteString("&apiGroups=")
+			result.WriteString(strings.Join(rule.APIGroups, ","))
+		}
 
-		result.WriteString("&resources=")
-		result.WriteString(strings.Join(rule.Resources, ","))
+		// resources
+		if len(rule.Resources) > 0 {
+			result.WriteString("&resources=")
+			result.WriteString(strings.Join(rule.Resources, ","))
+		}
 
-		result.WriteString("&resourceNames=")
-		result.WriteString(strings.Join(rule.ResourceNames, ","))
+		// resourceNames
+		if len(rule.ResourceNames) > 0 {
+			result.WriteString("&resourceNames=")
+			result.WriteString(strings.Join(rule.ResourceNames, ","))
+		}
 
-		result.WriteString("&nonResourceURLs=")
-		result.WriteString(strings.Join(rule.NonResourceURLs, ","))
-
+		// nonResourceURLs
+		if len(rule.NonResourceURLs) > 0 {
+			result.WriteString("&nonResourceURLs=")
+			result.WriteString(strings.Join(rule.NonResourceURLs, ","))
+		}
 	}
 
 	return result.String()


### PR DESCRIPTION
## Description
- Avoid crash for host-only ingress rules by guarding nil HTTP, PathType, and backend fields
- When Ingress rules may contain a host without HTTP paths
- Avoid crash for nil values of Role and ClusterRoleBinding functions
